### PR TITLE
Fix invalid markdown syntax & Update image paths for translated READMEs

### DIFF
--- a/translations/README_guj.md
+++ b/translations/README_guj.md
@@ -1,1672 +1,1231 @@
-
-
 # DeFi વિકાસકર્તા માર્ગ નકશો
 
- 
+**અહીં અમે શ્રેષ્ઠ ડીએફઆઈ અને બ્લોકચેન સંશોધન અને ટૂલ્સ એકત્રિત કરીએ છીએ અને તેની ચર્ચા કરીએ છીએ - યોગદાનનું સ્વાગત છે.**
 
-** અહીં અમે શ્રેષ્ઠ ડીએફઆઈ અને બ્લોકચેન સંશોધન અને ટૂલ્સ એકત્રિત કરીએ છીએ અને તેની ચર્ચા કરીએ છીએ - યોગદાનનું સ્વાગત છે. **
+**નાના સુધારાઓથી માંડીને અનુવાદો, ડsક્સ અથવા ટૂલ્સ પર તમે ઉમેરવા માંગતા હો તે કોઈપણ વસ્તુ સાથે પુલ વિનંતી સબમિટ કરો.**
 
- 
-
-** નાના સુધારાઓથી માંડીને અનુવાદો, ડsક્સ અથવા ટૂલ્સ પર તમે ઉમેરવા માંગતા હો તે કોઈપણ વસ્તુ સાથે પુલ વિનંતી સબમિટ કરો. **
-
- 
-
-[! [સપોર્ટ પ્રોજેક્ટ] (https://img.shields.io/badge/Support-Project-critical)] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#support-project) [ ! [સંશોધન આધાર] (https://img.shields.io/badge/Research-Base-lightgrey)] (https://github.com/OffcierCia/ultimate-defi-research-base) [! [LEGO દ્વારા સમર્થિત ] (https://img.shields.io/badge/Supported%20by-LEGO-%2300A3FF)] (https://www.notion.so/LEGO-Lido-Ecosystem-Grants-Organisation-d7f0bf0182d44348b6173639d2e8363d)! મેઇલ] (https://img.shields.io/badge/Mail-offcierciapr%40protonmail.com-brightgreen)] (મેઇલટો: ciફર્સિસીઆઆરપી@પ્રોટોનમેલ.કોમ)
-
- 
+[![સપોર્ટ પ્રોજેક્ટ](https://img.shields.io/badge/Support-Project-critical)](https://github.com/OffcierCia/DeFi-Developer-Road-Map#support-project) [ ![સંશોધન આધાર](https://img.shields.io/badge/Research-Base-lightgrey)](https://github.com/OffcierCia/ultimate-defi-research-base) [![LEGO દ્વારા સમર્થિત ](https://img.shields.io/badge/Supported%20by-LEGO-%2300A3FF)](https://www.notion.so/LEGO-Lido-Ecosystem-Grants-Organisation-d7f0bf0182d44348b6173639d2e8363d)
+![મેઇલ](https://img.shields.io/badge/Mail-offcierciapr%40protonmail.com-brightgreen)
 
 ## રોડમેપ
 
- 
+![રોડમેપ](../DeFiDevRroadMap_-4-Page-1.svg)
 
-! [રોડમેપ] (./ DeFiDevRroadMap_-Page-1.svg)
-
- 
 
 # સંશોધક
 
- 
-
 | વિષય | ત્વરિત કડી |
-
 |: ----------------: | ------------------------------ -------------------------------------------------- ------------------------------------------- |
-
-| મૂળભૂત | [અન્વેષણ] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#basics) |
-
-| dApps | [અન્વેષણ] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#dapps) |
-
-| ફ્રેમવર્ક | [અન્વેષણ] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#frameworks) |
-
-| zk-snarks | [અન્વેષણ કરો] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#zk-snarks) |
-
-| આગળ વાંચન | [અન્વેષણ કરો] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#f आगे-readings) |
-
-| સુરક્ષા | [અન્વેષણ] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#secures--safety) |
-
-| DeFi | [અન્વેષણ કરો] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#defi) |
-
-| ENS | [અન્વેષણ કરો] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#ethereum-name-service) |
-
+| મૂળભૂત | [અન્વેષણ](https://github.com/OffcierCia/DeFi-Developer-Road-Map#basics) |
+| dApps | [અન્વેષણ](https://github.com/OffcierCia/DeFi-Developer-Road-Map#dapps) |
+| ફ્રેમવર્ક | [અન્વેષણ](https://github.com/OffcierCia/DeFi-Developer-Road-Map#frameworks) |
+| zk-snarks | [અન્વેષણ કરો](https://github.com/OffcierCia/DeFi-Developer-Road-Map#zk-snarks) |
+| આગળ વાંચન | [અન્વેષણ કરો](https://github.com/OffcierCia/DeFi-Developer-Road-Map#f आगे-readings) |
+| સુરક્ષા | [અન્વેષણ](https://github.com/OffcierCia/DeFi-Developer-Road-Map#secures--safety) |
+| DeFi | [અન્વેષણ કરો](https://github.com/OffcierCia/DeFi-Developer-Road-Map#defi) |
+| ENS | [અન્વેષણ કરો](https://github.com/OffcierCia/DeFi-Developer-Road-Map#ethereum-name-service) |
 | એનએફટી | [અન્વેષણ કરો) (https://github.com/OffcierCia/DeFi-Developer-Road-Map#non-fungible-token-nft) |
-
-| સ્થિર સિક્કા | [અન્વેષણ] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#stable-coins) |
-
+| સ્થિર સિક્કા | [અન્વેષણ](https://github.com/OffcierCia/DeFi-Developer-Road-Map#stable-coins) |
 | સામાન્ય માહિતી | [અન્વેષણ કરો) (https://github.com/OffcierCia/DeFi-Developer-Road-Map#ethereum-tools) |
-
 | સાઇડ ચેઇન્સ | [અન્વેષણ કરો) (https://github.com/OffcierCia/DeFi-Developer-Road-Map#side-chains) |
+| એમઇવી | [અન્વેષણ કરો](https://github.com/OffcierCia/DeFi-Developer-Road-Map#mev---maximal-extractable-value--miner-extractable-value) |
+| સાધનો સંગ્રહ | [અન્વેષણ](https://github.com/OffcierCia/DeFi-Developer-Road-Map#tools-colલેક્શન) |
+| ETH 2.0 | [અન્વેષણ કરો](https://github.com/OffcierCia/DeFi-Developer-Road-Map#ethereum-20) |
+| ફ્રન્ટ એન્ડ | [અન્વેષણ કરો](https://github.com/OffcierCia/DeFi-Developer-Road-Map#front-end) |
 
-| એમઇવી | [અન્વેષણ કરો] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#mev---maximal-extractable-value--miner-extractable-value) |
 
-| સાધનો સંગ્રહ | [અન્વેષણ] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#tools-colલેક્શન) |
-
-| ETH 2.0 | [અન્વેષણ કરો] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#ethereum-20) |
-
-| ફ્રન્ટ એન્ડ | [અન્વેષણ કરો] (https://github.com/OffcierCia/DeFi-Developer-Road-Map#front-end) |
-
- 
-
- 
 
 # બેઝિક્સ:
 
- 
 
- 
 
-- ડિસ્ટ્રિબ્યુટેડ લેજર ટેક્નોલ (જી (ડીએલટી) ની મૂળ બાબતો જાણો.  
+- ડિસ્ટ્રિબ્યુટેડ લેજર ટેક્નોલ (જી (ડીએલટી) ની મૂળ બાબતો જાણો.
 
-- બિટકોઇન પ્રોટોકોલ [સમજાવાયેલ] (https://medium.com/coinmonks/bitcoin- white-paper - exPLined-part-1-4-16cba783146a)  
+- બિટકોઇન પ્રોટોકોલ [સમજાવાયેલ](https://medium.com/coinmonks/bitcoin- white-paper - exPLined-part-1-4-16cba783146a)
 
-- એલિપ્ટિક વળાંક [ક્રિપ્ટોગ્રાફી] (https://medium.com/coinmonks/learn-how-to-code-elliptic-curve-cryptography-a952dfdc20ab)  
+- એલિપ્ટિક વળાંક [ક્રિપ્ટોગ્રાફી](https://medium.com/coinmonks/learn-how-to-code-elliptic-curve-cryptography-a952dfdc20ab)
 
-- [બ્લોકચેન સમજાવાયેલ] વાંચો (https://www.investopedia.com/terms/b/ blockchain.asp)  
+- [બ્લોકચેન સમજાવાયેલ] વાંચો (https://www.investopedia.com/terms/b/ blockchain.asp)
 
-- જુઓ [બ્લોકચેન - એક દ્રશ્ય ડેમો] (https://www.youtube.com/watch?v=_160oMzblY8)  
-
- 
+- જુઓ [બ્લોકચેન - એક દ્રશ્ય ડેમો](https://www.youtube.com/watch?v=_160oMzblY8)
 
 #### ઇથેરિયમ
 
- 
+- એથેરિયમની મૂળભૂત બાબતો જાણો
 
-- એથેરિયમની મૂળભૂત બાબતો જાણો  
+- એથેરિયમ વર્ચ્યુઅલ મશીન (ઇવીએમ): ટ Walરિંગ સંપૂર્ણ, વletsલેટ્સ, એકાઉન્ટ્સ (ઇઓએ), ખાનગી / જાહેર કીઝ વિશે શીખો.
 
-- એથેરિયમ વર્ચ્યુઅલ મશીન (ઇવીએમ): ટ Walરિંગ સંપૂર્ણ, વletsલેટ્સ, એકાઉન્ટ્સ (ઇઓએ), ખાનગી / જાહેર કીઝ વિશે શીખો.  
+- વ્યવહાર, ગેસ, મેટામાસ્ક વિશે જાણો
 
-- વ્યવહાર, ગેસ, મેટામાસ્ક વિશે જાણો  
+- ઇથેરિયમ ક્લાયન્ટ્સ / નોડ્સ, ગેથ
 
-- ઇથેરિયમ ક્લાયન્ટ્સ / નોડ્સ, ગેથ  
-
-- ઇન્ફુરા ઇન્ફ્રાસ્ટ્રક્ચર  
-
- 
+- ઇન્ફુરા ઇન્ફ્રાસ્ટ્રક્ચર
 
 #### સ્માર્ટ કરાર
 
- 
 
- 
 
-- સ્માર્ટ કરારની મૂળભૂત બાબતો  
+- સ્માર્ટ કરારની મૂળભૂત બાબતો
 
-- સ્માર્ટ કરારનું જીવન ચક્ર  
+- સ્માર્ટ કરારનું જીવન ચક્ર
 
-- ઇથેરિયમ ઉચ્ચ સ્તરની ભાષાઓ (** નક્કરતા **, વાઇપર, એલએલએલ, સર્પ)  
+- ઇથેરિયમ ઉચ્ચ સ્તરની ભાષાઓ (**નક્કરતા**, વાઇપર, એલએલએલ, સર્પ)
 
-- સ્માર્ટ કોન્ટ્રાક્ટ્સની રચના, પરીક્ષણ, ગોઠવણી  
+- સ્માર્ટ કોન્ટ્રાક્ટ્સની રચના, પરીક્ષણ, ગોઠવણી
 
-- web3.js અથવા web3.py નો ઉપયોગ કરીને સ્માર્ટ કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવી  
+- web3.js અથવા web3.py નો ઉપયોગ કરીને સ્માર્ટ કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવી
 
-- વાંચો [કોઈપણ રીતે ઇથેરિયમ કેવી રીતે કાર્ય કરે છે?] (Https://medium.com/@ppyhikasireddy/how-does-ethereum-work-anyway-22d1df506369)  
+- વાંચો [કોઈપણ રીતે ઇથેરિયમ કેવી રીતે કાર્ય કરે છે?](Https://medium.com/@ppyhikasireddy/how-does-ethereum-work-anyway-22d1df506369)
 
-- [આ લેખ] વાંચો (https://blog.zeppelin.solutions/the-hitchhikers-guide-to-smart-contracts-in-ethereum-848f08001f05)  
+- [આ લેખ] વાંચો (https://blog.zeppelin.solutions/the-hitchhikers-guide-to-smart-contracts-in-ethereum-848f08001f05)
 
-- [ટ્રફલ ડોક્યુમેન્ટેશન] (https://truffleframework.com/docs/) / [હાર્ડહટ ડોક્યુમેન્ટેશન] (https://hardhat.org/getting-started/) વાંચો  
+- [ટ્રફલ ડોક્યુમેન્ટેશન](https://truffleframework.com/docs/) / [હાર્ડહટ ડોક્યુમેન્ટેશન](https://hardhat.org/getting-started/) વાંચો
 
-- [વેબ 3 દસ્તાવેજીકરણ] (https://web3js.readthedocs.io/en/1.0/) / [ઇથર્સ દસ્તાવેજીકરણ] (https://docs.ethers.io/v5/) વાંચો  
+- [વેબ 3 દસ્તાવેજીકરણ](https://web3js.readthedocs.io/en/1.0/) / [ઇથર્સ દસ્તાવેજીકરણ](https://docs.ethers.io/v5/) વાંચો
 
-- પુસ્તક વાંચો [માસ્ટરિંગ ઇથેરિયમ] (https://github.com/ethereumbook/ethereumbook)  
+- પુસ્તક વાંચો [માસ્ટરિંગ ઇથેરિયમ](https://github.com/ethereumbook/ethereumbook)
 
-- [સોલિડિટી સ્માર્ટ કરાર લાઇબ્રેરી] વાંચો (https://openzeppelin.org/api/docs/get-started.html)  
-
- 
+- [સોલિડિટી સ્માર્ટ કરાર લાઇબ્રેરી] વાંચો (https://openzeppelin.org/api/docs/get-started.html)
 
 #### સ્માર્ટ કરાર ધોરણો
 
- 
-
-- [ERCs] (https://eips.ethereum.org/erc) - ઇથેરિયમ ઇમ્પ્રૂવમેન્ટ પ્રસ્તાવો  
-
- 
+- [ERCs](https://eips.ethereum.org/erc) - ઇથેરિયમ ઇમ્પ્રૂવમેન્ટ પ્રસ્તાવો
 
 #### ટોકન્સ
 
- 
+- [ERC-20](https://eips.ethereum.org/Eips/eip-20) - ફંગિબલ સંપત્તિ માટેનો ટોકન કરાર.
 
-- [ERC-20] (https://eips.ethereum.org/Eips/eip-20) - ફંગિબલ સંપત્તિ માટેનો ટોકન કરાર.  
+- [ERC-721](https://github.com/ethereum/eips/issues/721) - નોન-ફંગિબલ સંપત્તિ માટેનું ટોકન ધોરણ.
 
-- [ERC-721] (https://github.com/ethereum/eips/issues/721) - નોન-ફંગિબલ સંપત્તિ માટેનું ટોકન ધોરણ.  
-
-- [ERC-918] (https://eips.ethereum.org/Eips/eip-918) - ખનિજ ટોકન ધોરણ.  
-
- 
+- [ERC-918](https://eips.ethereum.org/Eips/eip-918) - ખનિજ ટોકન ધોરણ.
 
 #### અન્ય
 
- 
+- [ERC-165](https://eips.ethereum.org/Eips/eip-165) - સ્માર્ટ કરારના અમલીકરણ માટે કયા ઇન્ટરફેસો પ્રકાશિત કરે છે અને શોધવા માટે એક માનક પદ્ધતિ બનાવે છે.
 
-- [ERC-165] (https://eips.ethereum.org/Eips/eip-165) - સ્માર્ટ કરારના અમલીકરણ માટે કયા ઇન્ટરફેસો પ્રકાશિત કરે છે અને શોધવા માટે એક માનક પદ્ધતિ બનાવે છે.  
+- [ERC-725](https://eips.ethereum.org/Eips/eip-725) - સરળ પ્રોક્સી એકાઉન્ટ માટેનું એક માનક ઇન્ટરફેસ.
 
-- [ERC-725] (https://eips.ethereum.org/Eips/eip-725) - સરળ પ્રોક્સી એકાઉન્ટ માટેનું એક માનક ઇન્ટરફેસ.  
+- [ERC-173](https://eips.ethereum.org/Eips/eip-173) - કરારોની માલિકીનું એક માનક ઇન્ટરફેસ.
 
-- [ERC-173] (https://eips.ethereum.org/Eips/eip-173) - કરારોની માલિકીનું એક માનક ઇન્ટરફેસ.  
 
- 
-
- 
 
 #### સામાન્ય વિકાસ કુશળતા
 
- 
 
- 
 
-- જાણો [જીઆઇટી] (https://medium.com/pixel-pioneers/the-basics-of-version-control-system-git-explained-by-designing-a-new-car-3fb3a10e9e40)  
+- જાણો [જીઆઇટી](https://medium.com/pixel-pioneers/the-basics-of-version-control-system-git-explained-by-designing-a-new-car-3fb3a10e9e40)
 
-- [ગીટહબ] (https://github.com/) / [ગિટલેબ] (https://about.gitlab.com/) પર થોડા ભંડારો બનાવો.  
+- [ગીટહબ](https://github.com/) / [ગિટલેબ](https://about.gitlab.com/) પર થોડા ભંડારો બનાવો.
 
-- તમારો કોડ અન્ય લોકો સાથે જાણો HTTP (S) પ્રોટોકોલ, વિનંતી પદ્ધતિઓ (GET, POST, PUT, PATCH, કાLEી નાખો, વિકલ્પો) જાણો  
+- તમારો કોડ અન્ય લોકો સાથે જાણો HTTP (S) પ્રોટોકોલ, વિનંતી પદ્ધતિઓ (GET, POST, PUT, PATCH, કાLEી નાખો, વિકલ્પો) જાણો
 
-- ગૂગલ, [ગૂગલ સાથે પાવર સર્ચિંગ] નો ઉપયોગ કરવાથી ડરશો નહીં (http://www.powersearchingwithgoogle.com/)  
+- ગૂગલ, [ગૂગલ સાથે પાવર સર્ચિંગ] નો ઉપયોગ કરવાથી ડરશો નહીં (http://www.powersearchingwithgoogle.com/)
 
-- ટર્મિનલ ([Linux / Docker] (https://medium.com/coinmonks/how-to-become-a- blockchain-developer-59c830e20f15)) થી પરિચિત થાઓ, તમારા શેલને ગોઠવો (bash, zsh, માછલી)  
+- ટર્મિનલ ([Linux / Docker](https://medium.com/coinmonks/how-to-become-a- blockchain-developer-59c830e20f15)) થી પરિચિત થાઓ, તમારા શેલને ગોઠવો (bash, zsh, માછલી)
 
-- એલ્ગોરિધમ્સ અને ડેટા સ્ટ્રક્ચર્સ, બ્લોકચેન, ઇથેરિયમ, એકતા વિશેના કેટલાક પુસ્તકો વાંચો  
+- એલ્ગોરિધમ્સ અને ડેટા સ્ટ્રક્ચર્સ, બ્લોકચેન, ઇથેરિયમ, એકતા વિશેના કેટલાક પુસ્તકો વાંચો
 
-- આ અભ્યાસક્રમ કરો [ઇથેરિયમ અને સોલિડિટી: સંપૂર્ણ વિકાસકર્તાની માર્ગદર્શિકા] (https://www.udemy.com/ethereum-and-olity-the-complete-developers-guide/)  
+- આ અભ્યાસક્રમ કરો [ઇથેરિયમ અને સોલિડિટી: સંપૂર્ણ વિકાસકર્તાની માર્ગદર્શિકા](https://www.udemy.com/ethereum-and-olity-the-complete-developers-guide/)
 
-- મફત ટ્યુટોરિયલ [શીખવાની સોલિડિ] (https://github.com/willitscale/learning-solidity)  
+- મફત ટ્યુટોરિયલ [શીખવાની સોલિડિ](https://github.com/willitscale/learning-solidity)
 
-- [સોલિડિટી સાથે સ્માર્ટ કરાર વિકાસના પરિચય] (https://www.youtube.com/playlist?list=PLV1JDFUtrXpGvu8QHL9b78WYNSJsYNZsb)  
-
- 
+- [સોલિડિટી સાથે સ્માર્ટ કરાર વિકાસના પરિચય](https://www.youtube.com/playlist?list=PLV1JDFUtrXpGvu8QHL9b78WYNSJsYNZsb)
 
 #### આ ટૂલ્સ અજમાવો:
 
- 
+- [ઇથ-ક્લીક](https://github.com/protofire/eth-cli) - સીએલઆઈ ટૂલ્સ.
 
-- [ઇથ-ક્લીક] (https://github.com/protofire/eth-cli) - સીએલઆઈ ટૂલ્સ.  
+- [REPL](https://github.com/rainorshine/solidity-repl) - નક્કરતા REPL.
 
-- [REPL] (https://github.com/rainorshine/solidity-repl) - નક્કરતા REPL.  
+- [રીમિક્સ](https://remix.ethereum.org/) - realનલાઇન રીઅલટાઇમ કમ્પાઇલર અને રનટાઇમ.
 
-- [રીમિક્સ] (https://remix.ethereum.org/) - realનલાઇન રીઅલટાઇમ કમ્પાઇલર અને રનટાઇમ.  
 
- 
-
- 
 
 # ડીએપીએસ
 
- 
-
-- તમે જે સાધનોનો ઉપયોગ કરી રહ્યાં છો તેનાથી પરિચિત થાઓ:  
-
- 
+- તમે જે સાધનોનો ઉપયોગ કરી રહ્યાં છો તેનાથી પરિચિત થાઓ:
 
 #### પેકેજ મેનેજરો
 
- 
+- [npm](https://www.npmjs.com/)
 
-- [npm] (https://www.npmjs.com/)  
+- [યાર્ન](https://yarnpkg.com/lang/en/)
 
-- [યાર્ન] (https://yarnpkg.com/lang/en/)  
-
-- [પીએનએમ] [https://pnpm.js.org/)  
-
- 
+- [પીએનએમ] [https://pnpm.js.org/)
 
 #### IDE ની
 
- 
+- [રીમિક્સ IDE](https://remix.ethereum.org/)
 
-- [રીમિક્સ IDE] (https://remix.ethereum.org/)  
+- [એથફિલ્ડ](https://ethfiddle.com/)
 
-- [એથફિલ્ડ] (https://ethfiddle.com/)  
+- [labs.super block](https://superblocks.com/)
 
-- [labs.super block] (https://superblocks.com/)  
+- [ટ્રફલ](https://truffleframework.com/)
 
-- [ટ્રફલ] (https://truffleframework.com/)  
+- [સોલિડિટી v0.5.3](https://solidity.readthedocs.io/en/v0.5.3/)
 
-- [સોલિડિટી v0.5.3] (https://solidity.readthedocs.io/en/v0.5.3/)  
+- [વાઇપર](https://github.com/ethereum/vyper)
 
-- [વાઇપર] (https://github.com/ethereum/vyper)  
+- [અણુ](https://atom.io/)
 
-- [અણુ] (https://atom.io/)  
+- [ઇથેરટોમ](https://atom.io/packages/etheratom)
 
-- [ઇથેરટોમ] (https://atom.io/packages/etheratom)  
+- [સ્વતomપૂર્ણ સોલિડિટી](https://atom.io/packages/autocomplete-solity)
 
-- [સ્વતomપૂર્ણ સોલિડિટી] (https://atom.io/packages/autocomplete-solity)  
+- [ભાષા નક્કરતા](https://atom.io/packages/language-solidity)
 
-- [ભાષા નક્કરતા] (https://atom.io/packages/language-solidity)  
+- [વિમ સોલિડિટી](https://github.com/tomlion/vim-solity)
 
-- [વિમ સોલિડિટી] (https://github.com/tomlion/vim-solity)  
+- [યાકીન્દુ સોલિડિટી ટૂલ્સ](https://github.com/Yakindu/solidity-ide)
 
-- [યાકીન્દુ સોલિડિટી ટૂલ્સ] (https://github.com/Yakindu/solidity-ide)  
 
- 
-
- 
 
 #### પ્રેક્ટિસ
 
- 
+- [ઝોમ્બી ગેમ](https://cryptozombies.io/) બનાવીને ઇથેરિયમ વિકાસ જાણો
 
-- [ઝોમ્બી ગેમ] (https://cryptozombies.io/) બનાવીને ઇથેરિયમ વિકાસ જાણો  
+- વાંચો અને બનાવો અને ઉદાહરણ: [પાળતુ પ્રાણીની દુકાનનું ટ્યુટોરિયલ](https://www.trufflesuite.com/tutorial)
 
-- વાંચો અને બનાવો અને ઉદાહરણ: [પાળતુ પ્રાણીની દુકાનનું ટ્યુટોરિયલ] (https://www.trufflesuite.com/tutorial)  
+- [ટાઇમ-લ lockedક વ Walલેટ્સ: ઇથેરિયમ સ્માર્ટ કોન્ટ્રેક્ટ્સનો પરિચય](https://www.toptal.com/ethereum-smart-contract/time-locked-wallet-truffle-tutorial)
 
-- [ટાઇમ-લ lockedક વ Walલેટ્સ: ઇથેરિયમ સ્માર્ટ કોન્ટ્રેક્ટ્સનો પરિચય] (https://www.toptal.com/ethereum-smart-contract/time-locked-wallet-truffle-tutorial)  
+- [ધ અલ્ટીમેટ ઇ.એન.એસ. અને Đ એપ ટ્યુટોરિયલ](https://www.toptal.com/ethereum/ethereum-name-service-dapp-tutorial)
 
-- [ધ અલ્ટીમેટ ઇ.એન.એસ. અને Đ એપ ટ્યુટોરિયલ] (https://www.toptal.com/ethereum/ethereum-name-service-dapp-tutorial)  
+- [ઇથેરિયમ Ðએપ વિકાસ માટે અંતિમ પરિચય](https://www.youtube.com/playlist?list=PLV1JDFUtrXpFh85G-Dyy2kLSafaB9biQ)
 
-- [ઇથેરિયમ Ðએપ વિકાસ માટે અંતિમ પરિચય] (https://www.youtube.com/playlist?list=PLV1JDFUtrXpFh85G-Dyy2kLSafaB9biQ)  
+- [ઇથરનોટ](https://ethernaut.zeppelin.solutions/) એથેરિયમ શીખવામાં રસ ધરાવતા લોકો માટે વેબ 3 / સોલિડિટી આધારિત યુદ્ધવિરામ છે
 
-- [ઇથરનોટ] (https://ethernaut.zeppelin.solutions/) એથેરિયમ શીખવામાં રસ ધરાવતા લોકો માટે વેબ 3 / સોલિડિટી આધારિત યુદ્ધવિરામ છે  
+- [ઇથેરિયમ અને સોલિડિટી: સંપૂર્ણ વિકાસકર્તા માર્ગદર્શિકા](https://www.udemy.com/ethereum-and-solity-the-complete-developers-guide/)
 
-- [ઇથેરિયમ અને સોલિડિટી: સંપૂર્ણ વિકાસકર્તા માર્ગદર્શિકા] (https://www.udemy.com/ethereum-and-solity-the-complete-developers-guide/)  
+- [સંમતિ શ્રેષ્ઠ પ્રથાઓ](https://consensys.github.io/smart-contract-best-practices/) - આ દસ્તાવેજ મધ્યવર્તી સોલિડિટી પ્રોગ્રામરો માટે સુરક્ષા બાબતોનું મૂળભૂત જ્ providesાન પ્રદાન કરે છે. તેનું સંચાલન કન્સનસિસ ડાયિલિએન્સ અને વ્યાપક ઇથેરિયમ સમુદાય દ્વારા કરવામાં આવે છે.
 
-- [સંમતિ શ્રેષ્ઠ પ્રથાઓ] (https://consensys.github.io/smart-contract-best-practices/) - આ દસ્તાવેજ મધ્યવર્તી સોલિડિટી પ્રોગ્રામરો માટે સુરક્ષા બાબતોનું મૂળભૂત જ્ providesાન પ્રદાન કરે છે. તેનું સંચાલન કન્સનસિસ ડાયિલિએન્સ અને વ્યાપક ઇથેરિયમ સમુદાય દ્વારા કરવામાં આવે છે.  
-
-- [સોલિડિટી દાખલાઓ] (https://github.com/fravoll/solidity- Patterns) - દાખલાઓ અને શ્રેષ્ઠ પ્રયાસોનું સંકલન.  
-
- 
+- [સોલિડિટી દાખલાઓ](https://github.com/fravoll/solidity- Patterns) - દાખલાઓ અને શ્રેષ્ઠ પ્રયાસોનું સંકલન.
 
 # ઝેડકે-સ્નાર્ક
 
- 
-
 #### સામાન્ય માહિતી
 
- 
+- [ઝૂક્રેટ્સ](https://github.com/Zokrates/ZoKrates) - ઇથેરિયમ પર zkSNARKS માટે એક ટૂલબોક્સ
 
-- [ઝૂક્રેટ્સ] (https://github.com/Zokrates/ZoKrates) - ઇથેરિયમ પર zkSNARKS માટે એક ટૂલબોક્સ  
+- [ધ ઝેડટેક પ્રોટોકોલ](https://github.com/AztecProtocol/AZTEC) - ઇથેરિયમ નેટવર્ક પર ગુપ્ત વ્યવહારો, અમલીકરણ એથેરિયમ મેઇન-નેટ પર જીવંત છે.
 
-- [ધ ઝેડટેક પ્રોટોકોલ] (https://github.com/AztecProtocol/AZTEC) - ઇથેરિયમ નેટવર્ક પર ગુપ્ત વ્યવહારો, અમલીકરણ એથેરિયમ મેઇન-નેટ પર જીવંત છે.  
+- [નાઇટફfallલ](https://github.com/EYBlockchain/nightfall) - કોઈપણ ERC-20 / ERC-721 ટોકન ખાનગી બનાવો - ઓપન સોર્સ ટૂલ્સ અને માઇક્રો સર્વિસીસ
 
-- [નાઇટફfallલ] (https://github.com/EYBlockchain/nightfall) - કોઈપણ ERC-20 / ERC-721 ટોકન ખાનગી બનાવો - ઓપન સોર્સ ટૂલ્સ અને માઇક્રો સર્વિસીસ  
+- પ્રોક્સી ફરીથી એન્ક્રિપ્શન (PRE)
 
-- પ્રોક્સી ફરીથી એન્ક્રિપ્શન (PRE)  
+- [ન્યુસિફર નેટવર્ક](https://github.com/nucypher/nucypher) - વિકેન્દ્રિત સિસ્ટમોમાં ડેટા ગોપનીયતાને સશક્ત બનાવવા માટે પ્રોક્સી ફરીથી એન્ક્રિપ્શન નેટવર્ક
 
-- [ન્યુસિફર નેટવર્ક] (https://github.com/nucypher/nucypher) - વિકેન્દ્રિત સિસ્ટમોમાં ડેટા ગોપનીયતાને સશક્ત બનાવવા માટે પ્રોક્સી ફરીથી એન્ક્રિપ્શન નેટવર્ક  
+- [pyUmbral](https://github.com/nucypher/pyumbral) - થ્રેશોલ્ડ પ્રોક્સી ફરીથી એન્ક્રિપ્શન ક્રિપ્ટોગ્રાફિક લાઇબ્રેરી
 
-- [pyUmbral] (https://github.com/nucypher/pyumbral) - થ્રેશોલ્ડ પ્રોક્સી ફરીથી એન્ક્રિપ્શન ક્રિપ્ટોગ્રાફિક લાઇબ્રેરી  
+- સંપૂર્ણ હોમોમોર્ફિક એન્ક્રિપ્શન (FHE)
 
-- સંપૂર્ણ હોમોમોર્ફિક એન્ક્રિપ્શન (FHE)  
-
-- [ન્યુએફએચઇ] (https://github.com/nucypher/nufhe) - GPU એફએચઇ લાઇબ્રેરીને વેગ આપ્યો  
-
- 
+- [ન્યુએફએચઇ](https://github.com/nucypher/nufhe) - GPU એફએચઇ લાઇબ્રેરીને વેગ આપ્યો
 
 #### ઝેડકે-સ્ટાર્ક્સ
 
-- [સ્ટાર્કવેર] (https://github.com/starkware-industries) અને [StarkWare સંપત્તિ] (https://github.com/starkware-libs) - સ્ટાર્કએક્સ સ્કેલેબિલીટી એન્જિન સ્ટેટ ટ્રાંઝિશનને chainન-ચેન સ્ટોર કરે છે  
-
- 
+- [સ્ટાર્કવેર](https://github.com/starkware-industries) અને [StarkWare સંપત્તિ](https://github.com/starkware-libs) - સ્ટાર્કએક્સ સ્કેલેબિલીટી એન્જિન સ્ટેટ ટ્રાંઝિશનને chainન-ચેન સ્ટોર કરે છે
 
 # ફ્રેમવર્ક
 
- 
-
 #### ટ્રફલ સ્યૂટ
 
- 
+- [ટ્રફલ](https://truffleframework.com/truffle)
 
-- [ટ્રફલ] (https://truffleframework.com/truffle)  
+- [ગનાચે](https://truffleframework.com/ganache)
 
-- [ગનાચે] (https://truffleframework.com/ganache)  
+- [ઝરમર વરસાદ](https://truffleframework.com/drizzle)
 
-- [ઝરમર વરસાદ] (https://truffleframework.com/drizzle)  
 
- 
-
- 
 
 #### ઝેપ્લીનોઝ
 
- 
-
-- [પ્રારંભ કરી રહ્યા છીએ] (https://docs.zeppelinos.org/docs/start.html)  
-
- 
+- [પ્રારંભ કરી રહ્યા છીએ](https://docs.zeppelinos.org/docs/start.html)
 
 #### Labs.Super block
 
- 
+- [Labs.superblocks](https://lab.superblocks.com/)
 
-- [Labs.superblocks] (https://lab.superblocks.com/)  
+- [ડપ્પ ટ્યુટોરિયલ](https://www.youtube.com/watch?v=LK-kVMzrdno)
 
-- [ડપ્પ ટ્યુટોરિયલ] (https://www.youtube.com/watch?v=LK-kVMzrdno)  
 
- 
-
- 
 
 #### ઇન્ફુરા (એથેરિયમનો પ્રવેશદ્વાર)
 
- 
+- [મેનેનેટ એન્ડ પોઇન્ટ](https://infura.io/)
 
-- [મેનેનેટ એન્ડ પોઇન્ટ] (https://infura.io/)  
+- [રોપ્સેન ટેસ્ટનેટ એન્ડ પોઇન્ટ](https://infura.io/)
 
-- [રોપ્સેન ટેસ્ટનેટ એન્ડ પોઇન્ટ] (https://infura.io/)  
+- [કોવાન ટેસ્ટનેટ એન્ડ પોઇન્ટ](https://infura.io/)
 
-- [કોવાન ટેસ્ટનેટ એન્ડ પોઇન્ટ] (https://infura.io/)  
+- [રિંકબી ટેસ્ટનેટ એન્ડ પોઇન્ટ](https://infura.io/)
 
-- [રિંકબી ટેસ્ટનેટ એન્ડ પોઇન્ટ] (https://infura.io/)  
-
-- [આઈપીએફએસ] (https://medium.freecodecamp.org/hands-on-get-st সূવાય-with-infura-and-ipfs-on-ethereum-b63635142af0)  
-
- 
+- [આઈપીએફએસ](https://medium.freecodecamp.org/hands-on-get-st সূવાય-with-infura-and-ipfs-on-ethereum-b63635142af0)
 
 #### અન્ય માળખા
 
- 
+- [હાર્ડહટ](https://hardhat.org/) - લવચીક, એક્સ્ટેન્સિબલ અને ઝડપી ઇથેરિયમ વિકાસ પર્યાવરણ.
 
-- [હાર્ડહટ] (https://hardhat.org/) - લવચીક, એક્સ્ટેન્સિબલ અને ઝડપી ઇથેરિયમ વિકાસ પર્યાવરણ.  
+- [બ્રાઉની](https://github.com/iamdefinitelyahuman/brownie) - બ્રાઉની એથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સની જમાવટ, પરીક્ષણ અને ક્રિયાપ્રતિક્રિયા માટે પાયથોન માળખું છે.
 
-- [બ્રાઉની] (https://github.com/iamdefinitelyahuman/brownie) - બ્રાઉની એથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સની જમાવટ, પરીક્ષણ અને ક્રિયાપ્રતિક્રિયા માટે પાયથોન માળખું છે.  
+- [નવો ધંધો શરૂ કરવો](https://github.com/embark-framework/embark) - ડીએપી વિકાસ માટેનું ફ્રેમવર્ક
 
-- [નવો ધંધો શરૂ કરવો] (https://github.com/embark-framework/embark) - ડીએપી વિકાસ માટેનું ફ્રેમવર્ક  
+- [વેફલ](https://getwaffle.io/) - અદ્યતન સ્માર્ટ કરાર વિકાસ અને પરીક્ષણ, નાના, લવચીક, ઝડપી (એથર્સ.જેએસ પર આધારિત) માટેનું ફ્રેમવર્ક
 
-- [વેફલ] (https://getwaffle.io/) - અદ્યતન સ્માર્ટ કરાર વિકાસ અને પરીક્ષણ, નાના, લવચીક, ઝડપી (એથર્સ.જેએસ પર આધારિત) માટેનું ફ્રેમવર્ક  
+- [ડappપ](https://dapp.tools/dapp/) - ડીપ્લે વિકાસ માટે ફ્રેમવર્ક, ડીપ્લેના અનુગામી
 
-- [ડappપ] (https://dapp.tools/dapp/) - ડીપ્લે વિકાસ માટે ફ્રેમવર્ક, ડીપ્લેના અનુગામી  
+- [ઇથરલીમ](https://github.com/LimeChain/etherlime) - ડappપ જમાવટ માટે ઇથર્સ.જેએસ આધારિત માળખા
 
-- [ઇથરલીમ] (https://github.com/LimeChain/etherlime) - ડappપ જમાવટ માટે ઇથર્સ.જેએસ આધારિત માળખા  
+- [પરાસોલ](https://github.com/Lamarkaz/parasol) - પરીક્ષણ, INFURA જમાવટ, સ્વચાલિત કરાર દસ્તાવેજીકરણ અને વધુ સાથે ચપળ સ્માર્ટ કરાર વિકાસ પર્યાવરણ. તેમાં અમર્યાદિત કસ્ટમાઇઝિબિલીટી સાથે લવચીક અને અનઓપિનાઇટેડ ડિઝાઇન છે
 
-- [પરાસોલ] (https://github.com/Lamarkaz/parasol) - પરીક્ષણ, INFURA જમાવટ, સ્વચાલિત કરાર દસ્તાવેજીકરણ અને વધુ સાથે ચપળ સ્માર્ટ કરાર વિકાસ પર્યાવરણ. તેમાં અમર્યાદિત કસ્ટમાઇઝિબિલીટી સાથે લવચીક અને અનઓપિનાઇટેડ ડિઝાઇન છે  
+- [0xcert](https://github.com/0xcert/framework/) - વિકેન્દ્રિત એપ્લિકેશંસ બનાવવા માટે જાવાસ્ક્રિપ્ટ ફ્રેમવર્ક
 
-- [0xcert] (https://github.com/0xcert/framework/) - વિકેન્દ્રિત એપ્લિકેશંસ બનાવવા માટે જાવાસ્ક્રિપ્ટ ફ્રેમવર્ક  
+- [ઓપનઝેપ્પલિન એસડીકે](https://openzeppelin.com/sdk/) - ઓપનઝેપ્પલિન એસડીકે: સ્માર્ટ કરારને વિકસાવવા, કમ્પાઇલ કરવા, અપગ્રેડ કરવા, જમાવવા અને ક્રિયાપ્રતિક્રિયા કરવામાં સહાય માટે ટૂલ્સનો એક સ્યૂટ.
 
-- [ઓપનઝેપ્પલિન એસડીકે] (https://openzeppelin.com/sdk/) - ઓપનઝેપ્પલિન એસડીકે: સ્માર્ટ કરારને વિકસાવવા, કમ્પાઇલ કરવા, અપગ્રેડ કરવા, જમાવવા અને ક્રિયાપ્રતિક્રિયા કરવામાં સહાય માટે ટૂલ્સનો એક સ્યૂટ.  
+- [એસબીટી-ઇથેરિયમ](https://sbt-ethereum.io/) - વ walલેટ અને એબીઆઈ મેનેજમેન્ટ, ENS સપોર્ટ, અને અદ્યતન સ્કેલા એકીકરણ સહિત, સ્માર્ટ-કરાર ક્રિયાપ્રતિક્રિયા અને વિકાસ માટે એક ટેબ-પૂર્ણ, ટેક્સ્ટ-આધારિત કન્સોલ.
 
-- [એસબીટી-ઇથેરિયમ] (https://sbt-ethereum.io/) - વ walલેટ અને એબીઆઈ મેનેજમેન્ટ, ENS સપોર્ટ, અને અદ્યતન સ્કેલા એકીકરણ સહિત, સ્માર્ટ-કરાર ક્રિયાપ્રતિક્રિયા અને વિકાસ માટે એક ટેબ-પૂર્ણ, ટેક્સ્ટ-આધારિત કન્સોલ.  
+- [કોબ્રા](https://github.com / કોબ્રાફ્રેમવર્ક / કોબ્રા) - ઇથેરિયમ સ્માર્ટ કરાર, ઇથેરિયમ વર્ચ્યુઅલ મશીન (ઇવીએમ) પર પરીક્ષણ અને જમાવટ માટે ઝડપી, લવચીક અને સરળ વિકાસ પર્યાવરણ માળખું.
 
-- [કોબ્રા] (https://github.com / કોબ્રાફ્રેમવર્ક / કોબ્રા) - ઇથેરિયમ સ્માર્ટ કરાર, ઇથેરિયમ વર્ચ્યુઅલ મશીન (ઇવીએમ) પર પરીક્ષણ અને જમાવટ માટે ઝડપી, લવચીક અને સરળ વિકાસ પર્યાવરણ માળખું.  
+- [એપીરસ](https://docs.epirus.io/sdk/) - સ્માર્ટ કરાર બનાવવા માટે જાવા ફ્રેમવર્ક.
 
-- [એપીરસ] (https://docs.epirus.io/sdk/) - સ્માર્ટ કરાર બનાવવા માટે જાવા ફ્રેમવર્ક.  
 
- 
-
- 
 
 #### સ્માર્ટ કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવી
 
- 
+- [Web3.js](https://web3js.readthedocs.io/en/1.0/)
 
-- [Web3.js] (https://web3js.readthedocs.io/en/1.0/)  
+- [Web3.py](https://web3py.readthedocs.io/en/stable/)
 
-- [Web3.py] (https://web3py.readthedocs.io/en/stable/)  
-
-- [Web3j] (https://docs.web3j.io/latest/)  
-
- 
+- [Web3j](https://docs.web3j.io/latest/)
 
 #### પાયથોન ઇથેરિયમ ઇકો સિસ્ટમ
 
- 
-
-- [લેખ] (https://medium.com/@pipermerriam/the-python-ethereum-ecosystem-101bd9ba4de7)  
-
- 
+- [લેખ](https://medium.com/@pipermerriam/the-python-ethereum-ecosystem-101bd9ba4de7)
 
 #### વિતરિત સ્ટોરેજ સિસ્ટમ્સ
 
- 
+- [INFO](https://medium.com/bitfwd/hat-is-decentralised-stores-ipfs-filecoin-sia-storj-swarm-5509e476995f)
 
-- [INFO] (https://medium.com/bitfwd/hat-is-decentralised-stores-ipfs-filecoin-sia-storj-swarm-5509e476995f)  
+- [આઈપીએફએસ](https://ipfs.io/)
 
-- [આઈપીએફએસ] (https://ipfs.io/)  
+- [સ્વાર્મ](https://swarm-gateways.net/)
 
-- [સ્વાર્મ] (https://swarm-gateways.net/)  
+- [સ્ટોરજ](https://storj.io/)
 
-- [સ્ટોરજ] (https://storj.io/)  
-
-- [સિયા] (https://sia.tech/)  
-
- 
+- [સિયા](https://sia.tech/)
 
 #### બ્લોકચેન નેટવર્ક્સ
 
- 
+- [એથનોડ](https://github.com/vrde/ethnode) - વિકાસ માટે ઇથેરિયમ નોડ (ગેથ અથવા પેરિટી) ચલાવો, pm n બપોરે i -g એથનોડ અને & એથનોડ` જેટલું સરળ.
 
-- [એથનોડ] (https://github.com/vrde/ethnode) - વિકાસ માટે ઇથેરિયમ નોડ (ગેથ અથવા પેરિટી) ચલાવો, pm n બપોરે i -g એથનોડ અને & એથનોડ` જેટલું સરળ.  
+- [ગણશે](https://github.com/trufflesuite/ganache) - વિઝ્યુઅલ UI અને લોગ સાથે ઇથેરિયમ બ્લોકચેન પરીક્ષણ માટેની એપ્લિકેશન
 
-- [ગણશે] (https://github.com/trufflesuite/ganache) - વિઝ્યુઅલ UI અને લોગ સાથે ઇથેરિયમ બ્લોકચેન પરીક્ષણ માટેની એપ્લિકેશન  
+- [કાલિડો](https://kaleido.io/) - કન્સોર્ટિયમ બ્લોકચેન નેટવર્ક સ્પિન કરવા માટે કાલિડોનો ઉપયોગ કરો. પીઓસી અને પરીક્ષણ માટે સરસ
 
-- [કાલિડો] (https://kaleido.io/) - કન્સોર્ટિયમ બ્લોકચેન નેટવર્ક સ્પિન કરવા માટે કાલિડોનો ઉપયોગ કરો. પીઓસી અને પરીક્ષણ માટે સરસ  
+- [બેસુ પ્રાઈવેટ નેટવર્ક](https://besu.hyperledger.org/en/stable/Tutorials/Quickstarts/Azure-Private-Network-Quickstart/) - ડોકર કન્ટેનરમાં બેસુ નોડ્સનું ખાનગી નેટવર્ક ચલાવો
 
-- [બેસુ પ્રાઈવેટ નેટવર્ક] (https://besu.hyperledger.org/en/stable/Tutorials/Quickstarts/Azure-Private-Network-Quickstart/) - ડોકર કન્ટેનરમાં બેસુ નોડ્સનું ખાનગી નેટવર્ક ચલાવો  
+- [ઓરીઅન](https://github.com/PegaSysEng/orion) - પેગાસીસ દ્વારા ખાનગી વ્યવહાર કરવા માટેનો ભાગ
 
-- [ઓરીઅન] (https://github.com/PegaSysEng/orion) - પેગાસીસ દ્વારા ખાનગી વ્યવહાર કરવા માટેનો ભાગ  
+- [આર્ટેમિસ](https://github.com/PegaSysEng/artemis) - પેગાસીસ દ્વારા ઇથેરિયમ 2.0 બીકન ચેઇનનો જાવા અમલીકરણ
 
-- [આર્ટેમિસ] (https://github.com/PegaSysEng/artemis) - પેગાસીસ દ્વારા ઇથેરિયમ 2.0 બીકન ચેઇનનો જાવા અમલીકરણ  
+- [ક્લીક્વેબાઇટ](https://github.com/foam/cliquebait) - એકીકરણ અને સ્માર્ટ કોન્ટ્રાક્ટ એપ્લિકેશન્સના પરીક્ષણને ડોકરના દાખલાઓથી સાદા કરે છે જે વાસ્તવિક બ્લોકચેન નેટવર્કને મળતું આવે છે.
 
-- [ક્લીક્વેબાઇટ] (https://github.com/foam/cliquebait) - એકીકરણ અને સ્માર્ટ કોન્ટ્રાક્ટ એપ્લિકેશન્સના પરીક્ષણને ડોકરના દાખલાઓથી સાદા કરે છે જે વાસ્તવિક બ્લોકચેન નેટવર્કને મળતું આવે છે.  
+- [સ્થાનિક રાઇડન](https://github.com/ConsenSys/Local-Raiden) - ડેમો અને પરીક્ષણ હેતુ માટે ડોકર કન્ટેનરમાં સ્થાનિક રેઇડન નેટવર્ક ચલાવો
 
-- [સ્થાનિક રાઇડન] (https://github.com/ConsenSys/Local-Raiden) - ડેમો અને પરીક્ષણ હેતુ માટે ડોકર કન્ટેનરમાં સ્થાનિક રેઇડન નેટવર્ક ચલાવો  
+- [ખાનગી નેટવર્ક્સ જમાવટ સ્ક્રિપ્ટો](https://github.com/ConsenSys/private-networks-dep રોજગાર- સ્ક્રિપ્ટ્સ) - ખાનગી PoA નેટવર્ક્સ માટે આઉટ-ઓફ-બ depક્સ જમાવટ સ્ક્રિપ્ટ્સ
 
-- [ખાનગી નેટવર્ક્સ જમાવટ સ્ક્રિપ્ટો] (https://github.com/ConsenSys/private-networks-dep રોજગાર- સ્ક્રિપ્ટ્સ) - ખાનગી PoA નેટવર્ક્સ માટે આઉટ-ઓફ-બ depક્સ જમાવટ સ્ક્રિપ્ટ્સ  
+- [લોકલ ઇથેરિયમ નેટવર્ક](https://github.com/ConsenSys/local_ethereum_network) - ખાનગી PoW નેટવર્ક માટે આઉટ-ઓફ-બ depક્સ જમાવટ સ્ક્રિપ્ટ્સ
 
-- [લોકલ ઇથેરિયમ નેટવર્ક] (https://github.com/ConsenSys/local_ethereum_network) - ખાનગી PoW નેટવર્ક માટે આઉટ-ઓફ-બ depક્સ જમાવટ સ્ક્રિપ્ટ્સ  
+- [એઝેરેમ પર એથરિયમ](https://docs.mic Microsoft.com/en-us/azure/ blockchain/templates/ethereum-poa-d રોજગાર) - કન્સોર્ટિયમ Ethereum PoA નેટવર્ક્સની જમાવટ અને શાસન
 
-- [એઝેરેમ પર એથરિયમ] (https://docs.mic Microsoft.com/en-us/azure/ blockchain/templates/ethereum-poa-d રોજગાર) - કન્સોર્ટિયમ Ethereum PoA નેટવર્ક્સની જમાવટ અને શાસન  
+- [ગૂગલ ક્લાઉડ પર ઇથેરિયમ](https://console.cloud.google.com/marketplace/details/click-to-deploy-images/ethereum?filter=category:developer-tools) - ના પુરાવાના આધારે ઇથેરિયમ નેટવર્ક બનાવો. કામ
 
-- [ગૂગલ ક્લાઉડ પર ઇથેરિયમ] (https://console.cloud.google.com/marketplace/details/click-to-deploy-images/ethereum?filter=category:developer-tools) - ના પુરાવાના આધારે ઇથેરિયમ નેટવર્ક બનાવો. કામ  
+- [ઇન્ફુરા](https://infura.io/) - ઇથેરિયમ નેટવર્કનો ઇથેરિયમ API accessક્સેસ (મેનેટ, રોપ્સેન, રિંકબી, ગોઅરલી, કોવાન)
 
-- [ઇન્ફુરા] (https://infura.io/) - ઇથેરિયમ નેટવર્કનો ઇથેરિયમ API accessક્સેસ (મેનેટ, રોપ્સેન, રિંકબી, ગોઅરલી, કોવાન)  
+- [ક્લાઉડફ્લેર ડિસ્ટ્રિબ્યુટેડ વેબ ગેટવે](https://cloudflare.com/distributes-web-gateway/) - તમારું પોતાનું નોડ ચલાવવાને બદલે ક્લાઉડફ્લેર દ્વારા ઇથેરિયમ નેટવર્કની accessક્સેસ પ્રદાન કરે છે.
 
-- [ક્લાઉડફ્લેર ડિસ્ટ્રિબ્યુટેડ વેબ ગેટવે] (https://cloudflare.com/distributes-web-gateway/) - તમારું પોતાનું નોડ ચલાવવાને બદલે ક્લાઉડફ્લેર દ્વારા ઇથેરિયમ નેટવર્કની accessક્સેસ પ્રદાન કરે છે.  
+- [ચેઇનસ્ટેક](https://chainstack.com/) - વહેંચાયેલ અને સમર્પિત ઇથેરિયમ ગાંઠોને સેવા તરીકે (મેનેટ, રોપ્સેન, રિંકબી)
 
-- [ચેઇનસ્ટેક] (https://chainstack.com/) - વહેંચાયેલ અને સમર્પિત ઇથેરિયમ ગાંઠોને સેવા તરીકે (મેનેટ, રોપ્સેન, રિંકબી)  
+- [કીમિયો](https://alchemyapi.io/) - બ્લોકચેન ડેવલપર પ્લેટફોર્મ, ઇથેરિયમ એપીઆઈ અને નોડ સર્વિસ (મેનેટ, રોપ્સેન, રિંકબી, ગોર્લી, કોવાન)
 
-- [કીમિયો] (https://alchemyapi.io/) - બ્લોકચેન ડેવલપર પ્લેટફોર્મ, ઇથેરિયમ એપીઆઈ અને નોડ સર્વિસ (મેનેટ, રોપ્સેન, રિંકબી, ગોર્લી, કોવાન)  
-
-- [ઝેડએમઓકે] (https://zmok.io/) - જેએસઓન-આરપીસી ઇથેરિયમ એપીઆઇ (મેનેટ, રિંકબી, ફ્રન્ટ-રનિંગ મેનેટ)  
-
- 
+- [ઝેડએમઓકે](https://zmok.io/) - જેએસઓન-આરપીસી ઇથેરિયમ એપીઆઇ (મેનેટ, રિંકબી, ફ્રન્ટ-રનિંગ મેનેટ)
 
 #### ઇથર ફauક્સેસ
 
- 
+- [રિન્કબી પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ](https://faucet.rinkeby.io/)
 
-- [રિન્કબી પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ] (https://faucet.rinkeby.io/)  
+- [કોવાન પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ](https://github.com/kovan-testnet/faucet)
 
-- [કોવાન પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ] (https://github.com/kovan-testnet/faucet)  
+- [રોપ્સેન પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ (મેટામાસ્ક)](https://faucet.metamask.io/)
 
-- [રોપ્સેન પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ (મેટામાસ્ક)] (https://faucet.metamask.io/)  
+- [ગોરેલી પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ](https://goerli-faucet.slock.it/)
 
-- [ગોરેલી પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ] (https://goerli-faucet.slock.it/)  
+- [સાર્વત્રિક પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ](https://faucets. blockxlabs.com/)
 
-- [સાર્વત્રિક પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ] (https://faucets. blockxlabs.com/)  
+- [નેથેરિયમ.ફauસેટ](https://github.com/Nethereum/Nethereum.Faucet) - AC # /. NET પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ
 
-- [નેથેરિયમ.ફauસેટ] (https://github.com/Nethereum/Nethereum.Faucet) - AC # /. NET પ્રવાહી વહેવાનો હરકોઈ જાતનો નળ  
 
- 
-
- 
 
 # ફ્રન્ટ એન્ડ
 
- 
-
 #### UI ઘટકો
 
- 
+- [સત્તાવાર વેબસાઇટ] પર પ્રતિક્રિયા શીખો (https://reactjs.org/tutorial/tutorial.html) અથવા કેટલાક [અભ્યાસક્રમો] પૂર્ણ કરો (https://egghead.io/courses/the-beginner-s-guide-to- પ્રતિક્રિયા)
 
-- [સત્તાવાર વેબસાઇટ] પર પ્રતિક્રિયા શીખો (https://reactjs.org/tutorial/tutorial.html) અથવા કેટલાક [અભ્યાસક્રમો] પૂર્ણ કરો (https://egghead.io/courses/the-beginner-s-guide-to- પ્રતિક્રિયા)  
+- [રોડમેપ પર પ્રતિક્રિયા આપો) (https://github.com/adam-golab/react-developer-roadmap)
 
-- [રોડમેપ પર પ્રતિક્રિયા આપો) (https://github.com/adam-golab/react-developer-roadmap)  
+- [એરેગનયુઆઈ](https://ui.aragon.org) - ડappપ ઘટકો સહિતની પ્રતિક્રિયા પુસ્તકાલય
 
-- [એરેગનયુઆઈ] (https://ui.aragon.org) - ડappપ ઘટકો સહિતની પ્રતિક્રિયા પુસ્તકાલય  
+- [ઘટકો.bounties.network](https://compferences.bounties.network) - ડappપ ઘટકો સહિતની પ્રતિક્રિયા પુસ્તકાલય
 
-- [ઘટકો.bounties.network] (https://compferences.bounties.network) - ડappપ ઘટકો સહિતની પ્રતિક્રિયા પુસ્તકાલય  
+- [ui.decentraland.org](https://github.com/decentraland/ui) - ડ Reપ ઘટકો સહિતની પ્રતિક્રિયા પુસ્તકાલય
 
-- [ui.decentraland.org] (https://github.com/decentraland/ui) - ડ Reપ ઘટકો સહિતની પ્રતિક્રિયા પુસ્તકાલય  
+- [ડાપ્પરટસ](https://github.com/austintgriffith/dapparatus) - ફરીથી વાપરી શકાય તેવી પ્રતિક્રિયા ડappપ ઘટકો
 
-- [ડાપ્પરટસ] (https://github.com/austintgriffith/dapparatus) - ફરીથી વાપરી શકાય તેવી પ્રતિક્રિયા ડappપ ઘટકો  
+- [મેટામાસ્ક યુઆઈ](https://github.com/MetaMask/metamask-extension/tree/develop/ui/app/compferences) - મેટામાસ્ક પ્રતિક્રિયા ઘટકો
 
-- [મેટામાસ્ક યુઆઈ] (https://github.com/MetaMask/metamask-extension/tree/develop/ui/app/compferences) - મેટામાસ્ક પ્રતિક્રિયા ઘટકો  
+- [ડappપહાયબ્રીડ](https://github.com/Nethereum/Nethereum.DappHybrid) - વેબ આધારિત વિકેન્દ્રિત એપ્લિકેશન્સ માટે ક્રોસ-પ્લેટફોર્મ હાઇબ્રિડ હોસ્ટિંગ મિકેનિઝમ
 
-- [ડappપહાયબ્રીડ] (https://github.com/Nethereum/Nethereum.DappHybrid) - વેબ આધારિત વિકેન્દ્રિત એપ્લિકેશન્સ માટે ક્રોસ-પ્લેટફોર્મ હાઇબ્રિડ હોસ્ટિંગ મિકેનિઝમ  
+- [નેથેરિયમ.યુઆઇ.ડેસ્કટtopપ](https://github.com/Nethereum/Nethereum.UI.Desktop) - ક્રોસ-પ્લેટફોર્મ ડેસ્કટ desktopપ વletલેટ નમૂના
 
-- [નેથેરિયમ.યુઆઇ.ડેસ્કટtopપ] (https://github.com/Nethereum/Nethereum.UI.Desktop) - ક્રોસ-પ્લેટફોર્મ ડેસ્કટ desktopપ વletલેટ નમૂના  
+- [ઇથ-બટન](https://eth-button.github.io/eth-button/) - ઓછામાં ઓછા દાન બટન
 
-- [ઇથ-બટન] (https://eth-button.github.io/eth-button/) - ઓછામાં ઓછા દાન બટન  
+- [રેમ્બલ ડિઝાઇન સિસ્ટમ](https://rimble.consensys.design/) - વિકેન્દ્રિત એપ્લિકેશનો માટે અનુકૂલનશીલ ઘટકો અને ડિઝાઇન ધોરણો.
 
-- [રેમ્બલ ડિઝાઇન સિસ્ટમ] (https://rimble.consensys.design/) - વિકેન્દ્રિત એપ્લિકેશનો માટે અનુકૂલનશીલ ઘટકો અને ડિઝાઇન ધોરણો.  
+- [3 બBક્સ પ્લગઇન્સ](https://docs.3box.io/build/plugins) - સામાજિક કાર્યક્ષમતા માટે પ્રતિક્રિયા ઘટકોમાં ઘટાડો. ટિપ્પણીઓ, પ્રોફાઇલ્સ અને સંદેશા સહિત.
 
-- [3 બBક્સ પ્લગઇન્સ] (https://docs.3box.io/build/plugins) - સામાજિક કાર્યક્ષમતા માટે પ્રતિક્રિયા ઘટકોમાં ઘટાડો. ટિપ્પણીઓ, પ્રોફાઇલ્સ અને સંદેશા સહિત.  
 
- 
-
- 
 
 # આગળ વાંચન
 
- 
-
 #### દ્વારા પ્રેરિત:
 
- 
+- [ઇટીએચ ડappપ ડેવલપર રોડમેપ](https://github.com/thecryptoshed/eth-dapp-developer-roadmap)
 
-- [ઇટીએચ ડappપ ડેવલપર રોડમેપ] (https://github.com/thecryptoshed/eth-dapp-developer-roadmap)  
+- [ડેફાઇ સંરક્ષણ ડીએઓ ટૂલ્સ](https://github.com/defi-defense-dao/defi-risk-tools-list#developer-tools)
 
-- [ડેફાઇ સંરક્ષણ ડીએઓ ટૂલ્સ] (https://github.com/defi-defense-dao/defi-risk-tools-list#developer-tools)  
+- [બ્લોકચેન લર્નિંગ પાથ](https://github.com/protofire/ blockchain-learning-path)
 
-- [બ્લોકચેન લર્નિંગ પાથ] (https://github.com/protofire/ blockchain-learning-path)  
+- [ADF](https://github.com/ong/awesome-decentralized-finance)
 
-- [ADF] (https://github.com/ong/awesome-decentralized-finance)  
+- [DeFi ટૂલકિટ](https://github.com/gweicz/defi-toolkit)
 
-- [DeFi ટૂલકિટ] (https://github.com/gweicz/defi-toolkit)  
+- [બ્લોકટૂલ](https://github.com/nujabes403/ blockchains-tools)
 
-- [બ્લોકટૂલ] (https://github.com/nujabes403/ blockchains-tools)  
+- [સ.અ.વ. સૂચિ](https://simpleaswater.com/defi/#analytics)
 
-- [સ.અ.વ. સૂચિ] (https://simpleaswater.com/defi/#analytics)  
+- [સાર્વજનિક APIs) (https://github.com/public-apis/public-apis#cryptocurrency)
 
-- [સાર્વજનિક APIs) (https://github.com/public-apis/public-apis#cryptocurrency)  
+- [બીટીસી સૂચિ](https://github.com/igorbarinov/awesome-bitcoin)
 
-- [બીટીસી સૂચિ] (https://github.com/igorbarinov/awesome-bitcoin)  
+- [કોન્સનસિસ](https://github.com/ConsenSys/ethereum-developer-tools-list)
 
-- [કોન્સનસિસ] (https://github.com/ConsenSys/ethereum-developer-tools-list)  
+- [ઇવીએમ ટૂલ્સ](https://github.com/CoinCल्चर / જીવંત- ટૂલ્સ)
 
-- [ઇવીએમ ટૂલ્સ] (https://github.com/CoinCल्चर / જીવંત- ટૂલ્સ)  
+- [સોલિડિટી પ્રો](https://github.com/bkrem/awesome-solidity)
 
-- [સોલિડિટી પ્રો] (https://github.com/bkrem/awesome-solidity)  
+- [ઝિહુ રિસર્ચ બેઝ](https://zhuanlan.zhihu.com/p/265374061)
 
-- [ઝિહુ રિસર્ચ બેઝ] (https://zhuanlan.zhihu.com/p/265374061)  
+- [ઓપનઝેપ્લિન - કરારો / પરીક્ષણ સહાયકો + વધુ](https://github.com/OpenZeppelin)
 
-- [ઓપનઝેપ્લિન - કરારો / પરીક્ષણ સહાયકો + વધુ] (https://github.com/OpenZeppelin)  
+- [અદ્ભુત ઇથેરિયમ રિસોર્સ સૂચિઓ](https://medium.com/quiknode/awesome-ethereum-resource-lists-dd28a9c17fc1)
 
-- [અદ્ભુત ઇથેરિયમ રિસોર્સ સૂચિઓ] (https://medium.com/quiknode/awesome-ethereum-resource-lists-dd28a9c17fc1)  
+- [કોમ્પ્રિહેન્સિવ ઇથેરિયમ ડેવલપર રિસોર્સ લિસ્ટ](https://github.com/ConsenSys/ethereum-developer-tools-list/blob/master/README.md)
 
-- [કોમ્પ્રિહેન્સિવ ઇથેરિયમ ડેવલપર રિસોર્સ લિસ્ટ] (https://github.com/ConsenSys/ethereum-developer-tools-list/blob/master/README.md)  
+- [સ્માર્ટ કોન્ટ્રાક્ટ લર્નિંગ](https://github.com/arbazkiraak/SmartContractLearning)
 
-- [સ્માર્ટ કોન્ટ્રાક્ટ લર્નિંગ] (https://github.com/arbazkiraak/SmartContractLearning)  
+- [અદ્ભુત ક્રિપ્ટોઇકોનોમિક્સ](https://github.com/jpantunes/awesome-cryptoeconomics)
 
-- [અદ્ભુત ક્રિપ્ટોઇકોનોમિક્સ] (https://github.com/jpantunes/awesome-cryptoeconomics)  
 
- 
-
- 
 
 #### સુરક્ષા અને સલામતી:
 
- 
+- [Horરusસની આંખ: ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સ પર સ્પોટિંગ અને વિશ્લેષણ કરનારા હુમલાઓ](https://arxiv.org/pdf/2101.06204.pdf) - તપાસ બતાવે છે કે છેલ્લા કેટલાક વર્ષોમાં હુમલાઓની સંખ્યામાં ઘટાડો થયો નથી, પરંતુ કેટલીક નબળાઈઓ માટે સ્થિર રહ્યા.
 
-- [Horરusસની આંખ: ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સ પર સ્પોટિંગ અને વિશ્લેષણ કરનારા હુમલાઓ] (https://arxiv.org/pdf/2101.06204.pdf) - તપાસ બતાવે છે કે છેલ્લા કેટલાક વર્ષોમાં હુમલાઓની સંખ્યામાં ઘટાડો થયો નથી, પરંતુ કેટલીક નબળાઈઓ માટે સ્થિર રહ્યા.  
+- [મોટા વ્યવહારો દ્વારા લાંચ લેવાના લાંચ આપનારા હુમલાઓ માટે બિટકોઇનની નબળાઈનું વિશ્લેષણ](https://arxiv.org/pdf/2105.07501.pdf) - આ કાગળમાં, લેખકો એક નવલકથા લાંચ આપનારા હુમલાની રચના કરે છે અને બતાવે છે કે આ બાંયધરીને ખૂબ જ ઓછી કરી શકાય છે.
 
- 
+- [ક્વોન્ટમ એટેક્સથી બ્લોકચેન ટેકનોલોજીની નબળાઈ](https://arxiv.org/pdf/2105.01815.pdf) - અહીં લેખકો આજે જમાવવામાં આવેલી મોટી બ્લોકચેન-આધારિત ક્રિપ્ટોક્યુરન્સીઝનું વિશ્લેષણ કરે છે - જેમાં બિટકોઇન, ઇથેરિયમ, લિટેકોઇન અને ઝેડકashશ શામેલ છે, અને નિર્ધારિત ક્વોન્ટમ એટેકનું જોખમ.
 
-- [મોટા વ્યવહારો દ્વારા લાંચ લેવાના લાંચ આપનારા હુમલાઓ માટે બિટકોઇનની નબળાઈનું વિશ્લેષણ] (https://arxiv.org/pdf/2105.07501.pdf) - આ કાગળમાં, લેખકો એક નવલકથા લાંચ આપનારા હુમલાની રચના કરે છે અને બતાવે છે કે આ બાંયધરીને ખૂબ જ ઓછી કરી શકાય છે.  
+- [બ્લLOCક](https://arxiv.org/pdf/2103.02873.pdf) - બ્લોકચેન પર DeFi એટેક્સ માટે શિકાર. આ કાગળમાં, લેખકોએ બ્લLOCકિએ, એથેરિયમ બ્લોકચેન પર ડેફાઇ પ્રોજેક્ટ્સ માટે રીઅલ-ટાઇમ એટેક ડિટેક્શન સિસ્ટમની દરખાસ્ત કરી.
 
- 
+- [ગતિશીલ મલ્ટિલેયર બ્લોકચેન નેટવર્ક્સમાં ટોપોલોજીકલ અસંગતતા શોધ](https://arxiv.org/pdf/2106.01806.pdf) - ગતિશીલ મલ્ટિલેયર નેટવર્કમાં રચનાત્મક વિસંગતતા શોધ માટે લેખકો નવો ટોપોલોજીકલ પરિપ્રેક્ષ્ય રજૂ કરે છે.
 
-- [ક્વોન્ટમ એટેક્સથી બ્લોકચેન ટેકનોલોજીની નબળાઈ] (https://arxiv.org/pdf/2105.01815.pdf) - અહીં લેખકો આજે જમાવવામાં આવેલી મોટી બ્લોકચેન-આધારિત ક્રિપ્ટોક્યુરન્સીઝનું વિશ્લેષણ કરે છે - જેમાં બિટકોઇન, ઇથેરિયમ, લિટેકોઇન અને ઝેડકashશ શામેલ છે, અને નિર્ધારિત ક્વોન્ટમ એટેકનું જોખમ.  
+- [ડેફની સાથે વૃદ્ધિશીલ મર્કલ ટ્રી એલ્ગોરિધમની ચકાસણી](https://arxiv.org/pdf/2105.06009.pdf) - લેખકો ડafફની મશીન-ચેકબલ સંસ્કરણ સાથે અલ્ગોરિધમનો અમારા નવા અને મૂળ શુદ્ધતાના પુરાવા રજૂ કરે છે.
 
- 
+- [ગોહેમર બ્લોકચેન પર્ફોર્મન્સ ટેસ્ટ ટૂલ](https://arxiv.org/pdf/2105.00847.pdf) - આ સાધન વધુ કાર્યક્ષમ વિકેન્દ્રિત સિસ્ટમ્સ વિકસાવવામાં મદદ કરશે અને વિકેન્દ્રિત એપ્લિકેશન પ્રોજેક્ટ્સના વિકાસના ખર્ચમાં ઘટાડો અસર કરશે.
 
-- [બ્લLOCક] (https://arxiv.org/pdf/2103.02873.pdf) - બ્લોકચેન પર DeFi એટેક્સ માટે શિકાર. આ કાગળમાં, લેખકોએ બ્લLOCકિએ, એથેરિયમ બ્લોકચેન પર ડેફાઇ પ્રોજેક્ટ્સ માટે રીઅલ-ટાઇમ એટેક ડિટેક્શન સિસ્ટમની દરખાસ્ત કરી.  
+- [ઇથરક્લુ: એથેરિયમ સ્માર્ટ કરાર પરના હુમલાઓની ડિજિટલ તપાસ](https://arxiv.org/pdf/2104.05293.pdf) - આ કાર્યમાં લેખકો ખાસ સમાધાનના સૂચકાંકોનો ઉપયોગ કરીને ઇથેરિયમ હુમલાઓની પોસ્ટ-ફેક્ટમ તપાસની સમસ્યાનો અભ્યાસ કરે છે. બ્લોકચેનમાં ઉપયોગ માટે રચાયેલ છે.
 
- 
+- [શક્ય વપરાશ કેસ દીઠ બ્લોકચેન પ્લેટફોર્મ્સના વિશ્લેષણ અને મૂલ્યાંકન] [https://arxiv.org/pdf/2103.03209.pdf) - આ દસ્તાવેજ બ્લોકચેન અને તેની એપ્લિકેશનોને સમજવા માટેનું સામાન્ય મોડેલ પ્રદાન કરે છે.
 
-- [ગતિશીલ મલ્ટિલેયર બ્લોકચેન નેટવર્ક્સમાં ટોપોલોજીકલ અસંગતતા શોધ] (https://arxiv.org/pdf/2106.01806.pdf) - ગતિશીલ મલ્ટિલેયર નેટવર્કમાં રચનાત્મક વિસંગતતા શોધ માટે લેખકો નવો ટોપોલોજીકલ પરિપ્રેક્ષ્ય રજૂ કરે છે.  
+- [કોન્સ્ટન્ટ ફંક્શન માર્કેટ ઉત્પાદકોમાં ગોપનીયતા પરની નોંધ](https://arxiv.org/pdf/2103.01193.pdf) - લેખકો દર્શાવે છે કે ગોપનીયતા, મોટાભાગના વાજબી મોડેલો હેઠળ સીએફએમએમના સામાન્ય અમલીકરણોથી અશક્ય છે. વિરોધી અને કેટલીક નિશ્ચિત વ્યૂહરચના પ્રદાન કરો.
 
- 
+- [ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સમાં એક સુરક્ષા સર્વેક્ષણની નબળાઈઓ](https://arxiv.org/pdf/2105.06974.pdf) - આ કાગળ આઠ ​​નબળાઈઓ સમજાવે છે જે આના શોષણ કેસના દૃશ્યોનું વિશ્લેષણ કરીને બીટીના એપ્લિકેશન સ્તર માટે વિશિષ્ટ છે. નબળાઈઓ.
 
-- [ડેફની સાથે વૃદ્ધિશીલ મર્કલ ટ્રી એલ્ગોરિધમની ચકાસણી] (https://arxiv.org/pdf/2105.06009.pdf) - લેખકો ડafફની મશીન-ચેકબલ સંસ્કરણ સાથે અલ્ગોરિધમનો અમારા નવા અને મૂળ શુદ્ધતાના પુરાવા રજૂ કરે છે.  
+- [ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સમાં સર્વિસ નબળાઈને નકારી કા toવાનો અભિગમ](https://arxiv.org/pdf/2106.01340.pdf) - આ પેપરમાં, લેખકોએ એક ફ્રેમવર્ક પ્રસ્તાવ મૂક્યું છે જે ડ Doસને શોધવા માટે સ્થિર અને ગતિશીલ વિશ્લેષણને જોડે છે. ઇટીએચ સ્માર્ટ કોન્ટ્રેક્ટમાં અનપેક્ષિત રીવર્ટ.
 
- 
+- [એજીસોલ્ટ: સોલિડિટી સ્માર્ટ કોન્ટ્રાક્ટ્સ માટે સ્વચાલિત ટેસ્ટ-કેસ જનરેશન માટેનું એક સાધન](https://arxiv.org/pdf/2102.08864.pdf) - લેખકોએ શોધી કા that્યું કે એજીએસએલટી એ બંને અભિગમો સાથે ઉચ્ચ શાખા ઓવરરેજ પ્રાપ્ત કરવામાં સક્ષમ છે અને તે પણ શોધાયેલ છે. ગીથબ પરના કેટલાક સૌથી લોકપ્રિય સોલિડિટી સ્માર્ટ કરારમાં કેટલીક ભૂલો.
 
-- [ગોહેમર બ્લોકચેન પર્ફોર્મન્સ ટેસ્ટ ટૂલ] (https://arxiv.org/pdf/2105.00847.pdf) - આ સાધન વધુ કાર્યક્ષમ વિકેન્દ્રિત સિસ્ટમ્સ વિકસાવવામાં મદદ કરશે અને વિકેન્દ્રિત એપ્લિકેશન પ્રોજેક્ટ્સના વિકાસના ખર્ચમાં ઘટાડો અસર કરશે.  
+- [ઇથેરિયમ ટ્રાંઝેક્શન ટ્રેકિંગ માટે ટેમ્પોરલ-રકમની સ્નેપશોટ મલ્ટિગ્રાફ](https://arxiv.org/pdf/2102.08013.pdf) - લેખકોએ ટેથોરલ-રકમ નેટવર્ક તરીકે ઇથેરિયમ ટ્રાન્ઝેક્શન રેકોર્ડ્સનું મોડેલ બનાવવા માટે TASMG પ્રસ્તાવ મૂક્યો અને પછી એકાઉન્ટ્સને અસરકારક રીતે એમ્બેડ કરવા માટે TAW પ્રસ્તુત કર્યું તેમના ટ્રાંઝેક્શન રેકોર્ડ્સ દ્વારા, જે સૂચિત નેટવર્કની ટેમ્પોરલ અને રકમની માહિતીને એકીકૃત કરે છે.
 
- 
+- [ક્રિપ્ટોકરન્સી માઇનીંગ એટેક્સને નકારી કા :વું: ડિજિટલ ફોરેન્સિક્સ અને ડાયનેમિક નેટવર્ક લાક્ષણિકતાઓ પર આધારીત અર્ધ-નિરીક્ષણ કરાયેલ અભિગમ](https://arxiv.org/pdf/2102.10634.pdf) - આ કાગળ સામાન્ય રીતે ક્રિપ્ટો માઇનિંગ હુમલાઓની શોધને સંબોધન કરે છે. ગતિશીલ નેટવર્ક લાક્ષણિકતાઓનો ઉપયોગ કરીને નેટવર્ક પર્યાવરણ.
 
-- [ઇથરક્લુ: એથેરિયમ સ્માર્ટ કરાર પરના હુમલાઓની ડિજિટલ તપાસ] (https://arxiv.org/pdf/2104.05293.pdf) - આ કાર્યમાં લેખકો ખાસ સમાધાનના સૂચકાંકોનો ઉપયોગ કરીને ઇથેરિયમ હુમલાઓની પોસ્ટ-ફેક્ટમ તપાસની સમસ્યાનો અભ્યાસ કરે છે. બ્લોકચેનમાં ઉપયોગ માટે રચાયેલ છે.  
+- [ફાસ્ટન: સ્માર્ટ કોન્ટ્રાક્ટ્સનો ઉપયોગ કરીને નિષ્પક્ષ અને સુરક્ષિત વિતરિત મતદાન](https://arxiv.org/pdf/2102.10594.pdf) - લેખકોએ સાબિત કર્યું છે કે ગોપનીયતા ભંગની સંભાવના નજીવી રીતે ઓછી છે. આગળ, ફેથનને ફાળવવાનું ખર્ચ વિશ્લેષણ એથેરિયમ ઉપર ચૂંટણીની હાલની મોટાભાગની કિંમતો સાથે તુલનાત્મક છે.
 
- 
+- [ખાણકામના ખર્ચ, ખાણકામના વળતર અને બ્લોકચેન સુરક્ષા વચ્ચેના આંતર નિર્ભરતાઓ](https://arxiv.org/pdf/2102.08107.pdf) - આ કાગળનો અભ્યાસ કરે છે કે પ્રૂફ-workફ-વર્ક બ્લોકચેનને ચલાવવા માટેની કિંમત કેટલી હદ સુધી જોડાયેલી છે. હુમલાઓ અટકાવવાનો ખર્ચ અને અંતર્ગત ડિજિટલ ખાતાવહી સુરક્ષા બજેટ ક્રિપ્ટોકરન્સી બજારના પરિણામો સાથે કેટલી હદ સુધી સબંધિત છે.
 
-- [શક્ય વપરાશ કેસ દીઠ બ્લોકચેન પ્લેટફોર્મ્સના વિશ્લેષણ અને મૂલ્યાંકન] [https://arxiv.org/pdf/2103.03209.pdf) - આ દસ્તાવેજ બ્લોકચેન અને તેની એપ્લિકેશનોને સમજવા માટેનું સામાન્ય મોડેલ પ્રદાન કરે છે.  
+- [હાયપરસેક: બ્લોકચેન સુરક્ષા મોનિટરિંગ માટે વિઝ્યુઅલ Analyનલિટિક્સ](https://arxiv.org/pdf/2103.14414.pdf) - હાયપરસેક, એક વિઝ્યુઅલ એનાલિટિક્સ મોનિટરિંગ ટૂલ જે હાયપરલ્ડર ફેબ્રિક પર ચાલી રહેલા હુમલાઓને શોધવા માટે એક નજરમાં સંબંધિત માહિતી પ્રદાન કરે છે.
 
- 
+- [એથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સમાં પુનર્જન્મની નબળાઈની ઓળખ] [https://arxiv.org/pdf/2105.02881.pdf) - આ પેપરમાં, લેખકો એક માળખું રજૂ કરે છે જે સ્થિર અને ગતિશીલ વિશ્લેષણને જોડીને ઇથેરિયમ સ્માર્ટ કોન્ટ્રેક્ટ્સમાં પુનર્જન્મની નબળાઈઓ શોધી કા .ે છે.
 
-- [કોન્સ્ટન્ટ ફંક્શન માર્કેટ ઉત્પાદકોમાં ગોપનીયતા પરની નોંધ] (https://arxiv.org/pdf/2103.01193.pdf) - લેખકો દર્શાવે છે કે ગોપનીયતા, મોટાભાગના વાજબી મોડેલો હેઠળ સીએફએમએમના સામાન્ય અમલીકરણોથી અશક્ય છે. વિરોધી અને કેટલીક નિશ્ચિત વ્યૂહરચના પ્રદાન કરો.  
+- [બ્લોકચેન પ્રોટોકોલના સુરક્ષા વિશ્લેષણ માટેનું એક સામાન્ય માળખું](https://arxiv.org/pdf/2009.09480v2.pdf) - આ કાગળ ઘણા જાણીતા પરવાનગી વિનાના બ્લોકચેન પ્રોટોકોલની મિલકતોને કબજે કરવા અને તેની તુલના કરવા માટે પર્યાપ્ત અમૂર્ત એબ્સ્ટ્રેક્શન રજૂ કરે છે. .
 
- 
+- [સિક્કાબગ્સ: સામાન્ય બ્લોકચેન અમલીકરણ-સ્તરની નબળાઈઓનું ગણતરી](https://arxiv.org/pdf/2104.06540.pdf) - કાગળનો હેતુ સુરક્ષા પરીક્ષકો અને બ્લોકચેન વિકાસકર્તાઓને સંદર્ભ રૂપે પ્રારંભ કરવાનું લક્ષ્ય રાખ્યું છે. સામાન્ય મુશ્કેલીઓ.
 
-- [ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સમાં એક સુરક્ષા સર્વેક્ષણની નબળાઈઓ] (https://arxiv.org/pdf/2105.06974.pdf) - આ કાગળ આઠ ​​નબળાઈઓ સમજાવે છે જે આના શોષણ કેસના દૃશ્યોનું વિશ્લેષણ કરીને બીટીના એપ્લિકેશન સ્તર માટે વિશિષ્ટ છે. નબળાઈઓ.  
+- [સ્માર્ટ કરારની નબળાઈઓ અને ખુલ્લા મુદ્દાઓ: એક સિસ્ટેમેટીક મેપિંગ](https://arxiv.org/pdf/2104.12295.pdf) - આ કાગળમાં એસસીનું વિશ્લેષણ કરવા માટેની પહેલ અને સાધનો ઓળખવા અને વ્યવહાર કેવી રીતે કરવો તે વ્યવસ્થિત સાહિત્યની મેપિંગ હાથ ધરવામાં આવ્યું. નબળાઈઓ ઓળખાય છે.
 
- 
+- [સુમો: સોલિડિટી સ્માર્ટ કોન્ટ્રાક્ટ્સ માટે એક પરિવર્તન પરીક્ષણ વ્યૂહરચના](https://arxiv.org/pdf/2105.03626.pdf) - લેખકો ખુલ્લા સ્ત્રોત પ્રોજેક્ટ્સ પર સુમોના પ્રથમ મૂલ્યાંકનની જાણ કરે છે જેના માટે પરીક્ષણ સેવાઓ ઉપલબ્ધ હતા. લેખકોને મળેલ પરિણામ પ્રોત્સાહક છે, અને તેઓ સૂચવે છે કે સુમો વિકાસકર્તાઓને વધુ વિશ્વસનીય સ્માર્ટ કરારો પહોંચાડવા માટે અસરકારક રીતે મદદ કરી શકે છે.
 
-- [ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સમાં સર્વિસ નબળાઈને નકારી કા toવાનો અભિગમ] (https://arxiv.org/pdf/2106.01340.pdf) - આ પેપરમાં, લેખકોએ એક ફ્રેમવર્ક પ્રસ્તાવ મૂક્યું છે જે ડ Doસને શોધવા માટે સ્થિર અને ગતિશીલ વિશ્લેષણને જોડે છે. ઇટીએચ સ્માર્ટ કોન્ટ્રેક્ટમાં અનપેક્ષિત રીવર્ટ.  
+- [(ઇન) બ્લોકચેન માટેની સ્થિરતા: ડિપરેજિંગ સ્પિરલ્સ અને સ્ટેબલકોઈન એટેક્સ](https://arxiv.org/pdf/1906.02152.pdf) - 2019 માં પેપરના પ્રારંભિક પ્રકાશનમાં સર્પાકારને કા deleી નાખવાની સંભાવના પ્રથમ આગાહી કરવામાં આવી હતી. પાછળથી 2020 માં ડાઇમાં બ્લેક ગુરુવારે કટોકટીની અવલોકન
 
- 
+- [બ્લોકચેન સિસ્ટમો પર અજ્onymાત ટ્રસ્ટ-માર્કિંગ યોજના](https://arxiv.org/pdf/2010.00206.pdf) - આ પેપરમાં, લેખકો બ્લોકચેન સિસ્ટમો પર અજ્ anાત ટ્રસ્ટ-માર્કિંગ યોજનાની દરખાસ્ત કરે છે જે કોઈપણ ક્રિપ્ટોકરન્સી પર સાર્વત્રિક રૂપે લાગુ પડે છે. .
 
-- [એજીસોલ્ટ: સોલિડિટી સ્માર્ટ કોન્ટ્રાક્ટ્સ માટે સ્વચાલિત ટેસ્ટ-કેસ જનરેશન માટેનું એક સાધન] (https://arxiv.org/pdf/2102.08864.pdf) - લેખકોએ શોધી કા that્યું કે એજીએસએલટી એ બંને અભિગમો સાથે ઉચ્ચ શાખા ઓવરરેજ પ્રાપ્ત કરવામાં સક્ષમ છે અને તે પણ શોધાયેલ છે. ગીથબ પરના કેટલાક સૌથી લોકપ્રિય સોલિડિટી સ્માર્ટ કરારમાં કેટલીક ભૂલો.  
+- [એથેરિયમ સ્માર્ટ કોન્ટ્રેક્ટ્સમાં બગ્સ માટેનું એક ફ્રેમવર્ક અને ડેટાસેટ](https://arxiv.org/pdf/2009.02066.pdf) - આ કાગળમાં, અંતર ભરવા માટે, લેખકો પહેલા ઘણા બધાથી શક્ય તેટલા સ્માર્ટ કરાર ભૂલો એકત્રિત કરે છે. સ્રોત અને આ ભૂલોને સોફ્ટવેર અસંગતતાઓ માટે આઇઇઇઇ સ્ટાન્ડર્ડ વર્ગીકરણને વિસ્તૃત કરીને 9 કેટેગરીમાં વહેંચો.
 
- 
+- [બ્લોકચેન નેટવર્ક્સમાં વિવિધ માઇનર્સ વર્તણૂક હુમલાઓ સામે એક સુરક્ષિત મલ્ટી ચેઇન્સ કન્સેન્સસ સ્કીમ.](Https://arxiv.org/pdf/2106.02383.pdf) - પ્રયોગાત્મક પરિણામો દર્શાવે છે કે ડીએમબી હુમલા સામે પીઓડીટી સુરક્ષિત છે અને પરંપરાગત કરતાં વધુ અસરકારક છે. મલ્ટી ચેઇન્સ વાતાવરણમાં સર્વસંમતિ યોજનાઓ.
 
-- [ઇથેરિયમ ટ્રાંઝેક્શન ટ્રેકિંગ માટે ટેમ્પોરલ-રકમની સ્નેપશોટ મલ્ટિગ્રાફ] (https://arxiv.org/pdf/2102.08013.pdf) - લેખકોએ ટેથોરલ-રકમ નેટવર્ક તરીકે ઇથેરિયમ ટ્રાન્ઝેક્શન રેકોર્ડ્સનું મોડેલ બનાવવા માટે TASMG પ્રસ્તાવ મૂક્યો અને પછી એકાઉન્ટ્સને અસરકારક રીતે એમ્બેડ કરવા માટે TAW પ્રસ્તુત કર્યું તેમના ટ્રાંઝેક્શન રેકોર્ડ્સ દ્વારા, જે સૂચિત નેટવર્કની ટેમ્પોરલ અને રકમની માહિતીને એકીકૃત કરે છે.  
+- [કન્સોર્ટિયમ બ્લોકચેન સંમતિ મિકેનિઝમ્સ પર એક સર્વે](https://arxiv.org/pdf/2102.12058.pdf) - આ પેપર એન્ટરપ્રાઇઝ બ્લોકચેન માટે સર્વસંમતિ ગાણિતીક નિયમોમાં ઘણાં અદ્યતન ઉકેલોને હાઇલાઇટ કરે છે.
 
- 
+- [કોકમાં પરીક્ષણ કરેલા અને ચકાસાયેલ સ્માર્ટ કોન્ટ્રેક્ટ્સ કાractીને] [https://arxiv.org/pdf/2012.09138.pdf) - મેટકોકોકના પ્રમાણિત ભૂંસવાના આધારે લેખકો કોક પ્રોગ્રામ્સને કાર્યકારી ભાષાઓમાં એક્સ્ટ્રક્શન લાગુ કરે છે.
 
-- [ક્રિપ્ટોકરન્સી માઇનીંગ એટેક્સને નકારી કા :વું: ડિજિટલ ફોરેન્સિક્સ અને ડાયનેમિક નેટવર્ક લાક્ષણિકતાઓ પર આધારીત અર્ધ-નિરીક્ષણ કરાયેલ અભિગમ] (https://arxiv.org/pdf/2102.10634.pdf) - આ કાગળ સામાન્ય રીતે ક્રિપ્ટો માઇનિંગ હુમલાઓની શોધને સંબોધન કરે છે. ગતિશીલ નેટવર્ક લાક્ષણિકતાઓનો ઉપયોગ કરીને નેટવર્ક પર્યાવરણ.  
+- [વિશ્વાસુ, ગોપનીયતા-સાચવનારા બ્લોકચેન પુલો](https://arxiv.org/pdf/2102.04660.pdf) - આ પેપરમાં, લેખકો પુલ ઉપાડની ગોપનીયતા જાળવનારા વિશ્વાસ-ઓછી ક્રોસ-ચેન ક્રિપ્ટોકરન્સી ટ્રાન્સફરની સુવિધા માટેનો પ્રોટોકોલ રજૂ કરે છે. .
 
- 
+- [ઇથેરિયમ સ્માર્ટ કરાર વિકાસ માટે સુરક્ષા ચેકલિસ્ટ્સ: દાખલાઓ અને શ્રેષ્ઠ પ્રયાસો](https://arxiv.org/pdf/2008.04761.pdf) - લેખકો સોફ્ટવેર જીવનચક્રની ડિઝાઇન, કોડિંગ અને પરીક્ષણ અને જમાવટના તબક્કાઓને આવરે છે.
 
-- [ફાસ્ટન: સ્માર્ટ કોન્ટ્રાક્ટ્સનો ઉપયોગ કરીને નિષ્પક્ષ અને સુરક્ષિત વિતરિત મતદાન] (https://arxiv.org/pdf/2102.10594.pdf) - લેખકોએ સાબિત કર્યું છે કે ગોપનીયતા ભંગની સંભાવના નજીવી રીતે ઓછી છે. આગળ, ફેથનને ફાળવવાનું ખર્ચ વિશ્લેષણ એથેરિયમ ઉપર ચૂંટણીની હાલની મોટાભાગની કિંમતો સાથે તુલનાત્મક છે.  
+- [મશીન લર્નિંગનો ઉપયોગ કરીને સ્માર્ટ કોન્ટ્રાક્ટ્સ પર ગતિશીલ નબળાઈ તપાસ]](https://arxiv.org/pdf/2102.07420.pdf) - આ કાર્યમાં લેખકો ડાયનેમિટની દરખાસ્ત કરે છે, જે ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સમાં પુનર્જન્મની નબળાઈઓ શોધવા માટે એક મોનિટરિંગ ફ્રેમવર્ક છે.
 
- 
+- [નબળા લિન્કને લક્ષ્યાંકિત કરી રહ્યા છે: ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સમાં સોશ્યલ એન્જિનિયરિંગ એટેક્સ](https://arxiv.org/pdf/2105.00132.pdf) - આ કાર્યમાં, લેખકો સ્માર્ટ કરારની હનીપોટ્સની બહાર નવા સામાજિક એન્જિનિયરિંગ હુમલાઓની શક્યતા અને અસ્તિત્વનું અન્વેષણ કરે છે. .
 
-- [ખાણકામના ખર્ચ, ખાણકામના વળતર અને બ્લોકચેન સુરક્ષા વચ્ચેના આંતર નિર્ભરતાઓ] (https://arxiv.org/pdf/2102.08107.pdf) - આ કાગળનો અભ્યાસ કરે છે કે પ્રૂફ-workફ-વર્ક બ્લોકચેનને ચલાવવા માટેની કિંમત કેટલી હદ સુધી જોડાયેલી છે. હુમલાઓ અટકાવવાનો ખર્ચ અને અંતર્ગત ડિજિટલ ખાતાવહી સુરક્ષા બજેટ ક્રિપ્ટોકરન્સી બજારના પરિણામો સાથે કેટલી હદ સુધી સબંધિત છે.  
+- [Optપ્ટસમાર્ટ: સ્માર્ટ કોન્ટ્રાક્ટ્સની એક સ્પેસ એફિંસ્ટીવ Opપ્ટિમેસ્ટિક કcનક્યુરન્ટ એક્ઝેક્યુશન](https://arxiv.org/pdf/2102.04875.pdf) - આ કાગળમાં લેખકો સમકાલીન ખાણિયો વિકસાવે છે જે optimસને એકસાથે આશાવાદી ઉપયોગ કરીને એક બ્લોકનો પ્રસ્તાવ આપે છે. સ Softwareફ્ટવેર ટ્રાંઝેક્શનલ મેમરી સિસ્ટમો (એસટીએમ).
 
- 
+- [ડિફેક્ટચેકર: ઇવીએમ બાયટેકોડનું વિશ્લેષણ કરીને સ્વચાલિત સ્માર્ટ કરાર ખામી શોધ]](https://arxiv.org/pdf/2009.02663.pdf) - પ્રાયોગિક પરિણામો બતાવે છે કે ડિફેક્ટચેકર ઝડપ અને ચોકસાઈ બંનેની દ્રષ્ટિએ આ સાધનો કરતા વધુ પ્રદર્શન કરે છે.
 
-- [હાયપરસેક: બ્લોકચેન સુરક્ષા મોનિટરિંગ માટે વિઝ્યુઅલ Analyનલિટિક્સ] (https://arxiv.org/pdf/2103.14414.pdf) - હાયપરસેક, એક વિઝ્યુઅલ એનાલિટિક્સ મોનિટરિંગ ટૂલ જે હાયપરલ્ડર ફેબ્રિક પર ચાલી રહેલા હુમલાઓને શોધવા માટે એક નજરમાં સંબંધિત માહિતી પ્રદાન કરે છે.  
+- [સ્માર્ટબગ્સ: સોલિડિટી સ્માર્ટ કરારનું વિશ્લેષણ કરવા માટેનું એક ફ્રેમવર્ક](https://arxiv.org/pdf/2007.04771.pdf) - લેખકો બતાવે છે કે તે કેવી રીતે સાધન સ્માર્ટચેક પર નવું એક્સ્ટેંશન પ્રસ્તુત કરીને વિશ્લેષણ સાધનોની સરખામણીને સરળ બનાવે છે. ડીએએસપી 10 કેટેગરીઝ ખરાબ રેન્ડમનેસ, ટાઇમ મેનીપ્યુલેશન અને એક્સેસ કંટ્રોલ (ઓળખાયેલી નબળાઈઓ 11% થી 24% સુધી વધી છે) થી સંબંધિત નબળાઈઓની તપાસમાં નોંધપાત્ર સુધારણા કરે છે.
 
- 
+- [સોલિડિટી સ્માર્ટ કોન્ટ્રાક્ટ્સમાં ગેસ લિકનું પ્રોફાઇલિંગ](https://arxiv.org/pdf/2008.05449.pdf) - લેખકો, સ્માર્ટ કરારની જમાવટ અને ટ્રાન્ઝેક્શન ખર્ચને અસર કરતી 19 સોલિડિટી કોડની ગંધનો સમૂહ ઓળખે છે, અને 34 સહભાગીઓ સામેલ એક સર્વે દ્વારા આવી ગંધની સુસંગતતાનું મૂલ્યાંકન કરો.
 
-- [એથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સમાં પુનર્જન્મની નબળાઈની ઓળખ] [https://arxiv.org/pdf/2105.02881.pdf) - આ પેપરમાં, લેખકો એક માળખું રજૂ કરે છે જે સ્થિર અને ગતિશીલ વિશ્લેષણને જોડીને ઇથેરિયમ સ્માર્ટ કોન્ટ્રેક્ટ્સમાં પુનર્જન્મની નબળાઈઓ શોધી કા .ે છે.  
+- [વેરિયેબલ માઇનીંગ પાવર હેઠળ સમાંતર સાંકળ પ્રોટોકોલ્સ સુરક્ષિત કરવું](https://arxiv.org/pdf/2105.02927.pdf) - આ પેપરમાં, લેખકો સુરક્ષિત સમાંતર-સાંકળ પ્રોટોકોલની રચનાને ધ્યાનમાં લે છે જે આવા ખાણકામ શક્તિને અનુરૂપ થઈ શકે છે. ભિન્નતા.
 
- 
+- [ડીપ ન્યુરલ નેટવર્ક અને ટ્રાન્સફર લર્નિંગનો ઉપયોગ કરીને ઇથેરિયમ સ્માર્ટકન્ટક્ટ નબળાઇ તપાસ]](https://arxiv.org/pdf/2103.12607.pdf) - ડીએનએન મોડેલ આર્કિટેક્ચરના ન્યૂનતમ ફેરફાર સાથે ESCORT ફ્રેમવર્ક નવા નબળાઈ પ્રકારો પર સ્થાનાંતરણ લર્નિંગને સક્ષમ કરે છે. તાલીમ ઓવરહેડ.
 
-- [બ્લોકચેન પ્રોટોકોલના સુરક્ષા વિશ્લેષણ માટેનું એક સામાન્ય માળખું] (https://arxiv.org/pdf/2009.09480v2.pdf) - આ કાગળ ઘણા જાણીતા પરવાનગી વિનાના બ્લોકચેન પ્રોટોકોલની મિલકતોને કબજે કરવા અને તેની તુલના કરવા માટે પર્યાપ્ત અમૂર્ત એબ્સ્ટ્રેક્શન રજૂ કરે છે. .  
+- [એસસીએસગાર્ડ: ઇથેરિયમ સ્માર્ટ કોન્ટ્રેક્ટ્સ માટે ડીપ સ્કેમ ડિટેક્શન](https://arxiv.org/pdf/2105.10426.pdf) - પ્રાયોગિક પરિણામો જાહેર કરે છે કે એસસીએસગાર્ડ ઉચ્ચ ચોકસાઈ (0.94) પ્રાપ્ત કરે છે, ચોકસાઇ (0.96%) અને રિકોલ (0.98) ) પોંઝી અને હનીપોટ સ્કેમ્સ અને નવા ફિશીંગ સ્માર્ટ કરાર બંને માટે છે.
 
- 
+- [બ્લોકચેન-આધારિત ડિજિટલ ટ્વિન્સ અને થ્રેટ ઇન્ટેલિજન્સ દ્વારા સાયબર-ફિઝિકલ સિસ્ટમોને સુરક્ષિત રાખવી](https://arxiv.org/pdf/2105.08886.pdf) - આ લેખ બુદ્ધિશાળી માટે કૃત્રિમ ગુપ્તચર (એઆઈ) અને બ્લોકચેનને એકીકૃત કરીને સીપીએસ સુરક્ષિત કરવા પર કેન્દ્રિત છે. અને વિશ્વસનીય ડી.ટી.
 
-- [સિક્કાબગ્સ: સામાન્ય બ્લોકચેન અમલીકરણ-સ્તરની નબળાઈઓનું ગણતરી] (https://arxiv.org/pdf/2104.06540.pdf) - કાગળનો હેતુ સુરક્ષા પરીક્ષકો અને બ્લોકચેન વિકાસકર્તાઓને સંદર્ભ રૂપે પ્રારંભ કરવાનું લક્ષ્ય રાખ્યું છે. સામાન્ય મુશ્કેલીઓ.  
 
- 
-
-- [સ્માર્ટ કરારની નબળાઈઓ અને ખુલ્લા મુદ્દાઓ: એક સિસ્ટેમેટીક મેપિંગ] (https://arxiv.org/pdf/2104.12295.pdf) - આ કાગળમાં એસસીનું વિશ્લેષણ કરવા માટેની પહેલ અને સાધનો ઓળખવા અને વ્યવહાર કેવી રીતે કરવો તે વ્યવસ્થિત સાહિત્યની મેપિંગ હાથ ધરવામાં આવ્યું. નબળાઈઓ ઓળખાય છે.  
-
- 
-
-- [સુમો: સોલિડિટી સ્માર્ટ કોન્ટ્રાક્ટ્સ માટે એક પરિવર્તન પરીક્ષણ વ્યૂહરચના] (https://arxiv.org/pdf/2105.03626.pdf) - લેખકો ખુલ્લા સ્ત્રોત પ્રોજેક્ટ્સ પર સુમોના પ્રથમ મૂલ્યાંકનની જાણ કરે છે જેના માટે પરીક્ષણ સેવાઓ ઉપલબ્ધ હતા. લેખકોને મળેલ પરિણામ પ્રોત્સાહક છે, અને તેઓ સૂચવે છે કે સુમો વિકાસકર્તાઓને વધુ વિશ્વસનીય સ્માર્ટ કરારો પહોંચાડવા માટે અસરકારક રીતે મદદ કરી શકે છે.  
-
- 
-
-- [(ઇન) બ્લોકચેન માટેની સ્થિરતા: ડિપરેજિંગ સ્પિરલ્સ અને સ્ટેબલકોઈન એટેક્સ] (https://arxiv.org/pdf/1906.02152.pdf) - 2019 માં પેપરના પ્રારંભિક પ્રકાશનમાં સર્પાકારને કા deleી નાખવાની સંભાવના પ્રથમ આગાહી કરવામાં આવી હતી. પાછળથી 2020 માં ડાઇમાં બ્લેક ગુરુવારે કટોકટીની અવલોકન  
-
- 
-
-- [બ્લોકચેન સિસ્ટમો પર અજ્onymાત ટ્રસ્ટ-માર્કિંગ યોજના] (https://arxiv.org/pdf/2010.00206.pdf) - આ પેપરમાં, લેખકો બ્લોકચેન સિસ્ટમો પર અજ્ anાત ટ્રસ્ટ-માર્કિંગ યોજનાની દરખાસ્ત કરે છે જે કોઈપણ ક્રિપ્ટોકરન્સી પર સાર્વત્રિક રૂપે લાગુ પડે છે. .  
-
- 
-
-- [એથેરિયમ સ્માર્ટ કોન્ટ્રેક્ટ્સમાં બગ્સ માટેનું એક ફ્રેમવર્ક અને ડેટાસેટ] (https://arxiv.org/pdf/2009.02066.pdf) - આ કાગળમાં, અંતર ભરવા માટે, લેખકો પહેલા ઘણા બધાથી શક્ય તેટલા સ્માર્ટ કરાર ભૂલો એકત્રિત કરે છે. સ્રોત અને આ ભૂલોને સોફ્ટવેર અસંગતતાઓ માટે આઇઇઇઇ સ્ટાન્ડર્ડ વર્ગીકરણને વિસ્તૃત કરીને 9 કેટેગરીમાં વહેંચો.  
-
- 
-
-- [બ્લોકચેન નેટવર્ક્સમાં વિવિધ માઇનર્સ વર્તણૂક હુમલાઓ સામે એક સુરક્ષિત મલ્ટી ચેઇન્સ કન્સેન્સસ સ્કીમ.] (Https://arxiv.org/pdf/2106.02383.pdf) - પ્રયોગાત્મક પરિણામો દર્શાવે છે કે ડીએમબી હુમલા સામે પીઓડીટી સુરક્ષિત છે અને પરંપરાગત કરતાં વધુ અસરકારક છે. મલ્ટી ચેઇન્સ વાતાવરણમાં સર્વસંમતિ યોજનાઓ.  
-
- 
-
-- [કન્સોર્ટિયમ બ્લોકચેન સંમતિ મિકેનિઝમ્સ પર એક સર્વે] (https://arxiv.org/pdf/2102.12058.pdf) - આ પેપર એન્ટરપ્રાઇઝ બ્લોકચેન માટે સર્વસંમતિ ગાણિતીક નિયમોમાં ઘણાં અદ્યતન ઉકેલોને હાઇલાઇટ કરે છે.  
-
- 
-
-- [કોકમાં પરીક્ષણ કરેલા અને ચકાસાયેલ સ્માર્ટ કોન્ટ્રેક્ટ્સ કાractીને] [https://arxiv.org/pdf/2012.09138.pdf) - મેટકોકોકના પ્રમાણિત ભૂંસવાના આધારે લેખકો કોક પ્રોગ્રામ્સને કાર્યકારી ભાષાઓમાં એક્સ્ટ્રક્શન લાગુ કરે છે.  
-
- 
-
-- [વિશ્વાસુ, ગોપનીયતા-સાચવનારા બ્લોકચેન પુલો] (https://arxiv.org/pdf/2102.04660.pdf) - આ પેપરમાં, લેખકો પુલ ઉપાડની ગોપનીયતા જાળવનારા વિશ્વાસ-ઓછી ક્રોસ-ચેન ક્રિપ્ટોકરન્સી ટ્રાન્સફરની સુવિધા માટેનો પ્રોટોકોલ રજૂ કરે છે. .  
-
- 
-
-- [ઇથેરિયમ સ્માર્ટ કરાર વિકાસ માટે સુરક્ષા ચેકલિસ્ટ્સ: દાખલાઓ અને શ્રેષ્ઠ પ્રયાસો] (https://arxiv.org/pdf/2008.04761.pdf) - લેખકો સોફ્ટવેર જીવનચક્રની ડિઝાઇન, કોડિંગ અને પરીક્ષણ અને જમાવટના તબક્કાઓને આવરે છે.  
-
- 
-
-- [મશીન લર્નિંગનો ઉપયોગ કરીને સ્માર્ટ કોન્ટ્રાક્ટ્સ પર ગતિશીલ નબળાઈ તપાસ]] (https://arxiv.org/pdf/2102.07420.pdf) - આ કાર્યમાં લેખકો ડાયનેમિટની દરખાસ્ત કરે છે, જે ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સમાં પુનર્જન્મની નબળાઈઓ શોધવા માટે એક મોનિટરિંગ ફ્રેમવર્ક છે.  
-
- 
-
-- [નબળા લિન્કને લક્ષ્યાંકિત કરી રહ્યા છે: ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સમાં સોશ્યલ એન્જિનિયરિંગ એટેક્સ] (https://arxiv.org/pdf/2105.00132.pdf) - આ કાર્યમાં, લેખકો સ્માર્ટ કરારની હનીપોટ્સની બહાર નવા સામાજિક એન્જિનિયરિંગ હુમલાઓની શક્યતા અને અસ્તિત્વનું અન્વેષણ કરે છે. .  
-
- 
-
-- [Optપ્ટસમાર્ટ: સ્માર્ટ કોન્ટ્રાક્ટ્સની એક સ્પેસ એફિંસ્ટીવ Opપ્ટિમેસ્ટિક કcનક્યુરન્ટ એક્ઝેક્યુશન] (https://arxiv.org/pdf/2102.04875.pdf) - આ કાગળમાં લેખકો સમકાલીન ખાણિયો વિકસાવે છે જે optimસને એકસાથે આશાવાદી ઉપયોગ કરીને એક બ્લોકનો પ્રસ્તાવ આપે છે. સ Softwareફ્ટવેર ટ્રાંઝેક્શનલ મેમરી સિસ્ટમો (એસટીએમ).  
-
- 
-
-- [ડિફેક્ટચેકર: ઇવીએમ બાયટેકોડનું વિશ્લેષણ કરીને સ્વચાલિત સ્માર્ટ કરાર ખામી શોધ]] (https://arxiv.org/pdf/2009.02663.pdf) - પ્રાયોગિક પરિણામો બતાવે છે કે ડિફેક્ટચેકર ઝડપ અને ચોકસાઈ બંનેની દ્રષ્ટિએ આ સાધનો કરતા વધુ પ્રદર્શન કરે છે.  
-
- 
-
-- [સ્માર્ટબગ્સ: સોલિડિટી સ્માર્ટ કરારનું વિશ્લેષણ કરવા માટેનું એક ફ્રેમવર્ક] (https://arxiv.org/pdf/2007.04771.pdf) - લેખકો બતાવે છે કે તે કેવી રીતે સાધન સ્માર્ટચેક પર નવું એક્સ્ટેંશન પ્રસ્તુત કરીને વિશ્લેષણ સાધનોની સરખામણીને સરળ બનાવે છે. ડીએએસપી 10 કેટેગરીઝ ખરાબ રેન્ડમનેસ, ટાઇમ મેનીપ્યુલેશન અને એક્સેસ કંટ્રોલ (ઓળખાયેલી નબળાઈઓ 11% થી 24% સુધી વધી છે) થી સંબંધિત નબળાઈઓની તપાસમાં નોંધપાત્ર સુધારણા કરે છે.  
-
- 
-
-- [સોલિડિટી સ્માર્ટ કોન્ટ્રાક્ટ્સમાં ગેસ લિકનું પ્રોફાઇલિંગ] (https://arxiv.org/pdf/2008.05449.pdf) - લેખકો, સ્માર્ટ કરારની જમાવટ અને ટ્રાન્ઝેક્શન ખર્ચને અસર કરતી 19 સોલિડિટી કોડની ગંધનો સમૂહ ઓળખે છે, અને 34 સહભાગીઓ સામેલ એક સર્વે દ્વારા આવી ગંધની સુસંગતતાનું મૂલ્યાંકન કરો.  
-
- 
-
-- [વેરિયેબલ માઇનીંગ પાવર હેઠળ સમાંતર સાંકળ પ્રોટોકોલ્સ સુરક્ષિત કરવું] (https://arxiv.org/pdf/2105.02927.pdf) - આ પેપરમાં, લેખકો સુરક્ષિત સમાંતર-સાંકળ પ્રોટોકોલની રચનાને ધ્યાનમાં લે છે જે આવા ખાણકામ શક્તિને અનુરૂપ થઈ શકે છે. ભિન્નતા.  
-
- 
-
-- [ડીપ ન્યુરલ નેટવર્ક અને ટ્રાન્સફર લર્નિંગનો ઉપયોગ કરીને ઇથેરિયમ સ્માર્ટકન્ટક્ટ નબળાઇ તપાસ]] (https://arxiv.org/pdf/2103.12607.pdf) - ડીએનએન મોડેલ આર્કિટેક્ચરના ન્યૂનતમ ફેરફાર સાથે ESCORT ફ્રેમવર્ક નવા નબળાઈ પ્રકારો પર સ્થાનાંતરણ લર્નિંગને સક્ષમ કરે છે. તાલીમ ઓવરહેડ.  
-
- 
-
-- [એસસીએસગાર્ડ: ઇથેરિયમ સ્માર્ટ કોન્ટ્રેક્ટ્સ માટે ડીપ સ્કેમ ડિટેક્શન] (https://arxiv.org/pdf/2105.10426.pdf) - પ્રાયોગિક પરિણામો જાહેર કરે છે કે એસસીએસગાર્ડ ઉચ્ચ ચોકસાઈ (0.94) પ્રાપ્ત કરે છે, ચોકસાઇ (0.96%) અને રિકોલ (0.98) ) પોંઝી અને હનીપોટ સ્કેમ્સ અને નવા ફિશીંગ સ્માર્ટ કરાર બંને માટે છે.  
-
- 
-
-- [બ્લોકચેન-આધારિત ડિજિટલ ટ્વિન્સ અને થ્રેટ ઇન્ટેલિજન્સ દ્વારા સાયબર-ફિઝિકલ સિસ્ટમોને સુરક્ષિત રાખવી] (https://arxiv.org/pdf/2105.08886.pdf) - આ લેખ બુદ્ધિશાળી માટે કૃત્રિમ ગુપ્તચર (એઆઈ) અને બ્લોકચેનને એકીકૃત કરીને સીપીએસ સુરક્ષિત કરવા પર કેન્દ્રિત છે. અને વિશ્વસનીય ડી.ટી.  
-
- 
-
- 
 
 #### ડે.એફ.આઇ.
 
- 
 
- 
 
-- [કમ્પોઝેબલ ડેફાઇ પ્રોટોકોલ્સનું Analપચારિક વિશ્લેષણ] (https://arxiv.org/pdf/2103.00540.pdf) - આ પેપરમાં, લેખકો efficientપચારિક પ્રક્રિયા-બીજગણિત તકનીકની દરખાસ્ત કરે છે કે જે કાર્યક્ષમ મિલકતને મંજૂરી આપવા માટે ડીફાઇ પ્રોટોકોલને રચનાત્મક રીતે મોડેલ આપે છે. ચકાસણી  
+- [કમ્પોઝેબલ ડેફાઇ પ્રોટોકોલ્સનું Analપચારિક વિશ્લેષણ](https://arxiv.org/pdf/2103.00540.pdf) - આ પેપરમાં, લેખકો efficientપચારિક પ્રક્રિયા-બીજગણિત તકનીકની દરખાસ્ત કરે છે કે જે કાર્યક્ષમ મિલકતને મંજૂરી આપવા માટે ડીફાઇ પ્રોટોકોલને રચનાત્મક રીતે મોડેલ આપે છે. ચકાસણી
 
- 
+- [ટ્રાન્ઝેક્શન ફી મિકેનિઝમ ડિઝાઇન](https://arxiv.org/pdf/2106.01340.pdf) - લેખકો બ્લોકચેન્સમાં ફીના વર્તનને સમજાવે છે.
 
-- [ટ્રાન્ઝેક્શન ફી મિકેનિઝમ ડિઝાઇન] (https://arxiv.org/pdf/2106.01340.pdf) - લેખકો બ્લોકચેન્સમાં ફીના વર્તનને સમજાવે છે.  
+- [ડેફાઇ-નિંગ ડેફાઇ: પડકારો અને પાથવે](https://arxiv.org/pdf/2101.05589.pdf) - વિકેન્દ્રિત ફાઇનાન્સની શરૂઆતની સારી રીટ્રોસ્પેક્ટિવ.
 
- 
+- [DeFi માં સ્વચાલિત બજાર ઉત્પાદકોનો એક સિદ્ધાંત](https://arxiv.org/pdf/2102.11350.pdf) - એએમએમના મૂળભૂત ગુણધર્મોના સમૂહને proveપચારિક રીતે સાબિત કરવા માટે લેખકો અમારા સિદ્ધાંતનું શોષણ કરે છે, જે માળખાકીય અને આર્થિક બંને પાસાઓને લાક્ષણિકતા આપે છે.
 
-- [ડેફાઇ-નિંગ ડેફાઇ: પડકારો અને પાથવે] (https://arxiv.org/pdf/2101.05589.pdf) - વિકેન્દ્રિત ફાઇનાન્સની શરૂઆતની સારી રીટ્રોસ્પેક્ટિવ.  
+- [બેંકોથી ડેફાઇ સુધી: ધિરાણ બજારનો ઉત્ક્રાંતિ](https://arxiv.org/pdf/2104.00970.pdf) - લેખકો પરંપરાગત નાણાકીય સિસ્ટમ પર દેફાઇ ધિરાણના સતત નિર્ભરતાની ચર્ચા કરે છે, અને તેના પરિપ્રેક્ષ્યના પરિપ્રેક્ષ્ય સાથે નિષ્કર્ષ લે છે. IOV યુગમાં ધિરાણ બજાર.
 
- 
+- [ડેફાઇ પ્રોટોકોલ્સમાં નફામાં ઉત્પન્ન થતા વ્યવહારોની જસ્ટ-ઇન-ટાઇમ ડિસ્કવરી પર](https://arxiv.org/pdf/2103.02228.pdf) -આ પેપરમાં, લેખકો બે પદ્ધતિઓની તપાસ કરે છે જે તેમને આપમેળે નફાકારક બનાવવા દે છે. DeFi વેપાર કરે છે.
 
-- [DeFi માં સ્વચાલિત બજાર ઉત્પાદકોનો એક સિદ્ધાંત] (https://arxiv.org/pdf/2102.11350.pdf) - એએમએમના મૂળભૂત ગુણધર્મોના સમૂહને proveપચારિક રીતે સાબિત કરવા માટે લેખકો અમારા સિદ્ધાંતનું શોષણ કરે છે, જે માળખાકીય અને આર્થિક બંને પાસાઓને લાક્ષણિકતા આપે છે.  
+- [ઓટોમેટેડ માર્કેટ ઉત્પાદકોના એક્સ્ટ્રેક્ટેબલ મૂલ્યને મહત્તમ બનાવવું](https://arxiv.org/pdf/2106.01870.pdf) - આ કાગળમાં લેખકો તર્કસંગત માઇનર્સને playersપચારિકરૂપે ખેલાડીઓ તરીકે લાક્ષણિકતા આપે છે જે ખાણની રમતમાં શ્રેષ્ઠ વ્યૂહરચનાને અનુસરે છે.
 
- 
+- [વિકેન્દ્રિત નાણાકીય કટોકટી](https://arxiv.org/pdf/2002.08099.pdf) - આ કાગળમાં લેખકો અન્વેષણ કરે છે કે કેવી રીતે ડીએફઆઈ પ્રોટોકોલ્સમાં ડિઝાઇનની નબળાઇઓ અને કિંમતની વધઘટ ડેફાઇ સંકટ તરફ દોરી શકે છે.
 
-- [બેંકોથી ડેફાઇ સુધી: ધિરાણ બજારનો ઉત્ક્રાંતિ] (https://arxiv.org/pdf/2104.00970.pdf) - લેખકો પરંપરાગત નાણાકીય સિસ્ટમ પર દેફાઇ ધિરાણના સતત નિર્ભરતાની ચર્ચા કરે છે, અને તેના પરિપ્રેક્ષ્યના પરિપ્રેક્ષ્ય સાથે નિષ્કર્ષ લે છે. IOV યુગમાં ધિરાણ બજાર.  
+- [લિક્વિડેશન્સ: ડીઇફાઇ ઓન એફ નોઇફ] [https://arxiv.org/pdf/2009.13235v4.pdf) - પ્રોટોકોલ્સને નુકસાનથી બચાવવા માટે, અંડરકોલેટેરાઇઝ્ડ સ્થિતિને ફડચા આપી શકાય છે. આ કાગળમાં, લેખકો લોન કરવા યોગ્ય ભંડોળ (પીએલએફ) માટેના પ્રોટોકોલ પર લિક્વિડેશનનું પ્રયોગમૂલક વિશ્લેષણ રજૂ કરે છે.
 
- 
+- [ડેફાઇ ઇન્ટિગ્રેશનના પ્રોક્સી તરીકે એસેટ કમ્પોઝિબિલિટીને માપી રહ્યા છે](https://arxiv.org/pdf/2102.04227.pdf) - લેખકો 'માં ટ્રાન્ઝેક્શનની તપાસ કરીને એથેરિયમ પર નાણાકીય એકીકરણમાં ફાળો આપી શકે છે તે ડિગ્રીને સમજવા માંગે છે. 2020 માં ગણતરીમાં લેવામાં આવેલા 344.8 મિલિયન ઇથેરિયમ ટ્રાન્ઝેક્શનના સંપૂર્ણ સેટ માટે સંપત્તિ ડીઆઈ, યુએસડીસી, યુએસડીટી, ઇટીએચ અને ટોકનાઇઝ્ડ બીટીસી માટેના ડેરિવેટિવ્ઝ.
 
-- [ડેફાઇ પ્રોટોકોલ્સમાં નફામાં ઉત્પન્ન થતા વ્યવહારોની જસ્ટ-ઇન-ટાઇમ ડિસ્કવરી પર] (https://arxiv.org/pdf/2103.02228.pdf) -આ પેપરમાં, લેખકો બે પદ્ધતિઓની તપાસ કરે છે જે તેમને આપમેળે નફાકારક બનાવવા દે છે. DeFi વેપાર કરે છે.  
+- [વિકેન્દ્રિત સ્વાયત્ત ક્રિપ્ટોકરન્સી એક્સચેન્જો માટે ગતિશીલ કર્વ્સ](https://arxiv.org/pdf/2101.02778.pdf) - લેખકોએ આ કાર્યમાં ગતિશીલ વળાંકના વિચારને પ્રસ્તાવિત કરીને એએમએમ બાંધવાનો નવો અભિગમ પ્રસ્તાવ આપ્યો છે.
 
- 
+- [વિકેન્દ્રિત ઓન-ચેન એક્સચેન્જેસ પરનું ઉચ્ચ-આવર્તન ટ્રેડિંગ](https://arxiv.org/pdf/2009.14021.pdf) - આ કાર્યમાં લેખકો ફ્રન્ટ-રનિંગના વધતા પ્રકારનું formalપચારિકકરણ કરે છે, વિશ્લેષણાત્મક રીતે એક્સપ્રેસ કરે છે અને અનુભવપૂર્ણ રીતે મૂલ્યાંકન કરે છે: સેન્ડવિચ એટેક , જેમાં ફ્રન્ટ- અને બેક-રનિંગ પીડિત TXs શામેલ છે.
 
-- [ઓટોમેટેડ માર્કેટ ઉત્પાદકોના એક્સ્ટ્રેક્ટેબલ મૂલ્યને મહત્તમ બનાવવું] (https://arxiv.org/pdf/2106.01870.pdf) - આ કાગળમાં લેખકો તર્કસંગત માઇનર્સને playersપચારિકરૂપે ખેલાડીઓ તરીકે લાક્ષણિકતા આપે છે જે ખાણની રમતમાં શ્રેષ્ઠ વ્યૂહરચનાને અનુસરે છે.  
+- [ફ્લેશટ](https://arxiv.org/pdf/2102.00626.pdf) - ડેફાઇ ઇકોસિસ્ટમ પર ફ્લેશ લોન એટેકનો સ્નેપશોટ.
 
- 
+- [DeFiRanger](https://arxiv.org/pdf/2104.15068.pdf) - ડીએફઆઇ એપ્લિકેશનો પર પ્રાઇસ મેનિપ્યુલેશન એટેકસ શોધી કા .વું.
 
-- [વિકેન્દ્રિત નાણાકીય કટોકટી] (https://arxiv.org/pdf/2002.08099.pdf) - આ કાગળમાં લેખકો અન્વેષણ કરે છે કે કેવી રીતે ડીએફઆઈ પ્રોટોકોલ્સમાં ડિઝાઇનની નબળાઇઓ અને કિંમતની વધઘટ ડેફાઇ સંકટ તરફ દોરી શકે છે.  
+- [ફન અને નફો માટે ફ્લેશ લોન્સ સાથે ડેફાઇ ઇકોસિસ્ટમ પર હુમલો કરવો](https://arxiv.org/pdf/2003.03810.pdf) - ફ્લેશ લોન્સ. DeFi. ઉત્તમ નમૂનાના.
 
- 
+- [એસ.ઓ.કે.: વિકેન્દ્રિત ફાઇનાન્સ (ડેફાઇ)](https://arxiv.org/pdf/2101.08778.pdf) - જ્ Systeાનના આ સિસ્ટમેટિએશન (એસ.ઓ.કે.) માં, લેખકોએ તેના મુખ્ય અક્ષો સાથે ડેઇફાઇ ઇકોસિસ્ટમને ચિત્રિત કરી. એસસીએસગાર્ડ: ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સ માટે ડીપ સ્કેમ ડિટેક્શન
 
-- [લિક્વિડેશન્સ: ડીઇફાઇ ઓન એફ નોઇફ] [https://arxiv.org/pdf/2009.13235v4.pdf) - પ્રોટોકોલ્સને નુકસાનથી બચાવવા માટે, અંડરકોલેટેરાઇઝ્ડ સ્થિતિને ફડચા આપી શકાય છે. આ કાગળમાં, લેખકો લોન કરવા યોગ્ય ભંડોળ (પીએલએફ) માટેના પ્રોટોકોલ પર લિક્વિડેશનનું પ્રયોગમૂલક વિશ્લેષણ રજૂ કરે છે.  
+- [ચાર ગવર્નન્સ ટોકન ડિસ્ટ્રિબ્યુશન્સના પ્રયોગમૂલક પૂરાવાઓ](https://arxiv.org/pdf/2102.10096.pdf) - આ કાગળ બ્લોકચેન એપ્લિકેશનોમાં શાસન શક્તિના વિકેન્દ્રીકરણને માપવા માટે એક માળખું પ્રદાન કરે છે.
 
- 
+- [બ્લોકચેન-આધારિત ડીસેન્ટ્રલાઇઝ્ડ એક્સચેન્જીસનું એડોપ્શન](https://arxiv.org/pdf/2103.08842.pdf) - લેખકો દર્શાવે છે કે જો બ્લોકચેન- ના ઓર્ડર એક્ઝેક્યુશન મિકેનિઝમને લીધે વિનિમય દર અસ્થિર હોય તો પ્રવાહીતા પ્રદાતાઓ ટોકન મૂલ્ય ગુમાવે છે. આધારિત વિનિમય.
 
-- [ડેફાઇ ઇન્ટિગ્રેશનના પ્રોક્સી તરીકે એસેટ કમ્પોઝિબિલિટીને માપી રહ્યા છે] (https://arxiv.org/pdf/2102.04227.pdf) - લેખકો 'માં ટ્રાન્ઝેક્શનની તપાસ કરીને એથેરિયમ પર નાણાકીય એકીકરણમાં ફાળો આપી શકે છે તે ડિગ્રીને સમજવા માંગે છે. 2020 માં ગણતરીમાં લેવામાં આવેલા 344.8 મિલિયન ઇથેરિયમ ટ્રાન્ઝેક્શનના સંપૂર્ણ સેટ માટે સંપત્તિ ડીઆઈ, યુએસડીસી, યુએસડીટી, ઇટીએચ અને ટોકનાઇઝ્ડ બીટીસી માટેના ડેરિવેટિવ્ઝ.  
+- [યુનિસ્વપ બજારોનું વિશ્લેષણ](https://arxiv.org/pdf/1911.03380.pdf) - યુનિસ્વાપ ડીએક્સ પ્રવૃત્તિ વિશેના શ્રેષ્ઠ અભ્યાસ પૈકીના એક, લેખકોએ 2019 માં સંશોધન કરવાનું શરૂ કર્યું અને તાજેતરમાં 2021 વિશ્લેષણ બહાર પાડ્યું.
 
- 
+- [ફાઇનાન્સ 4.0.૦: ટકાઉપણુંને ધ્યાન આપવા માટે મૂલ્ય-સંવેદનશીલ ક્રિપ્ટોઇકોનોમિક સિસ્ટમ માટે ડિઝાઇન સિદ્ધાંતો](https://arxiv.org/pdf/2105.11955.pdf) - લેખકો ક્રિપ્ટો સિસ્ટમ્સ ડિઝાઇન કરવા માટે નવી આંતરદૃષ્ટિ આપે છે.
 
-- [વિકેન્દ્રિત સ્વાયત્ત ક્રિપ્ટોકરન્સી એક્સચેન્જો માટે ગતિશીલ કર્વ્સ] (https://arxiv.org/pdf/2101.02778.pdf) - લેખકોએ આ કાર્યમાં ગતિશીલ વળાંકના વિચારને પ્રસ્તાવિત કરીને એએમએમ બાંધવાનો નવો અભિગમ પ્રસ્તાવ આપ્યો છે.  
+- [વિકેન્દ્રિત એક્સચેન્જીસમાં લિક્વિડિટી પ્રદાતાઓનું વર્તન](https://arxiv.org/pdf/2105.13822.pdf) - લેખકોએ તે સમજવાનું લક્ષ્ય રાખ્યું છે કે લિક્વિડિટી પ્રદાતાઓ માર્કેટની માહિતી પર કેવી પ્રતિક્રિયા આપે છે અને તેઓ ડીએક્સમાં પ્રવાહિતા પ્રદાન કરવામાં કેવી રીતે ફાયદો કરે છે.
 
- 
+- [વિકેન્દ્રિત વિનિમય બજારોમાં ચક્રીય આર્બિટ્રેજ](https://arxiv.org/pdf/2105.02784.pdf) - સારું વાંચો. આ કાગળ સૂચવે છે કે સ્માર્ટ કોન્ટ્રાક્ટ ટેકનોલોજી અને ઇથેરિયમની પ્રતિકૃતિવાળી રાજ્ય મશીન સેટિંગ સાથે, આર્સેટ્રેજ વ્યૂહરચનાઓ સીઈએક્સની તુલનામાં ડેક્સમાં સરળ અમલમાં છે.
 
-- [વિકેન્દ્રિત ઓન-ચેન એક્સચેન્જેસ પરનું ઉચ્ચ-આવર્તન ટ્રેડિંગ] (https://arxiv.org/pdf/2009.14021.pdf) - આ કાર્યમાં લેખકો ફ્રન્ટ-રનિંગના વધતા પ્રકારનું formalપચારિકકરણ કરે છે, વિશ્લેષણાત્મક રીતે એક્સપ્રેસ કરે છે અને અનુભવપૂર્ણ રીતે મૂલ્યાંકન કરે છે: સેન્ડવિચ એટેક , જેમાં ફ્રન્ટ- અને બેક-રનિંગ પીડિત TXs શામેલ છે.  
+- [સોકે: ગ્રાઉન્ડ ટ્રુથથી માર્કેટ મેનીપ્યુલેશન સુધીના ઓરેકલ્સ](https://arxiv.org/pdf/2106.00667.pdf) - આ સોકમાં, લેખકો ઓરેકલ્સ, શોકેસ હુમલાઓ માટેના ડિઝાઇન વિકલ્પોને વ્યવસ્થિત કરે છે, અને હુમલો ઘટાડવાની વ્યૂહરચના પર ચર્ચા કરે છે.
 
- 
+- [સ્વચાલિત બજાર ઉત્પાદકોના કમ્પોઝિંગ નેટવર્ક્સ](https://arxiv.org/pdf/2106.00083.pdf) - આ કાગળ એએમએમ કમ્પોઝિશન માટે ગાણિતિક મોડેલની દરખાસ્ત કરે છે.
 
-- [ફ્લેશટ] (https://arxiv.org/pdf/2102.00626.pdf) - ડેફાઇ ઇકોસિસ્ટમ પર ફ્લેશ લોન એટેકનો સ્નેપશોટ.  
 
- 
-
-- [DeFiRanger] (https://arxiv.org/pdf/2104.15068.pdf) - ડીએફઆઇ એપ્લિકેશનો પર પ્રાઇસ મેનિપ્યુલેશન એટેકસ શોધી કા .વું.  
-
- 
-
-- [ફન અને નફો માટે ફ્લેશ લોન્સ સાથે ડેફાઇ ઇકોસિસ્ટમ પર હુમલો કરવો] (https://arxiv.org/pdf/2003.03810.pdf) - ફ્લેશ લોન્સ. DeFi. ઉત્તમ નમૂનાના.  
-
- 
-
-- [એસ.ઓ.કે.: વિકેન્દ્રિત ફાઇનાન્સ (ડેફાઇ)] (https://arxiv.org/pdf/2101.08778.pdf) - જ્ Systeાનના આ સિસ્ટમેટિએશન (એસ.ઓ.કે.) માં, લેખકોએ તેના મુખ્ય અક્ષો સાથે ડેઇફાઇ ઇકોસિસ્ટમને ચિત્રિત કરી. એસસીએસગાર્ડ: ઇથેરિયમ સ્માર્ટ કોન્ટ્રાક્ટ્સ માટે ડીપ સ્કેમ ડિટેક્શન  
-
- 
-
-- [ચાર ગવર્નન્સ ટોકન ડિસ્ટ્રિબ્યુશન્સના પ્રયોગમૂલક પૂરાવાઓ] (https://arxiv.org/pdf/2102.10096.pdf) - આ કાગળ બ્લોકચેન એપ્લિકેશનોમાં શાસન શક્તિના વિકેન્દ્રીકરણને માપવા માટે એક માળખું પ્રદાન કરે છે.  
-
- 
-
-- [બ્લોકચેન-આધારિત ડીસેન્ટ્રલાઇઝ્ડ એક્સચેન્જીસનું એડોપ્શન] (https://arxiv.org/pdf/2103.08842.pdf) - લેખકો દર્શાવે છે કે જો બ્લોકચેન- ના ઓર્ડર એક્ઝેક્યુશન મિકેનિઝમને લીધે વિનિમય દર અસ્થિર હોય તો પ્રવાહીતા પ્રદાતાઓ ટોકન મૂલ્ય ગુમાવે છે. આધારિત વિનિમય.  
-
- 
-
-- [યુનિસ્વપ બજારોનું વિશ્લેષણ] (https://arxiv.org/pdf/1911.03380.pdf) - યુનિસ્વાપ ડીએક્સ પ્રવૃત્તિ વિશેના શ્રેષ્ઠ અભ્યાસ પૈકીના એક, લેખકોએ 2019 માં સંશોધન કરવાનું શરૂ કર્યું અને તાજેતરમાં 2021 વિશ્લેષણ બહાર પાડ્યું.  
-
- 
-
-- [ફાઇનાન્સ 4.0.૦: ટકાઉપણુંને ધ્યાન આપવા માટે મૂલ્ય-સંવેદનશીલ ક્રિપ્ટોઇકોનોમિક સિસ્ટમ માટે ડિઝાઇન સિદ્ધાંતો] (https://arxiv.org/pdf/2105.11955.pdf) - લેખકો ક્રિપ્ટો સિસ્ટમ્સ ડિઝાઇન કરવા માટે નવી આંતરદૃષ્ટિ આપે છે.  
-
- 
-
-- [વિકેન્દ્રિત એક્સચેન્જીસમાં લિક્વિડિટી પ્રદાતાઓનું વર્તન] (https://arxiv.org/pdf/2105.13822.pdf) - લેખકોએ તે સમજવાનું લક્ષ્ય રાખ્યું છે કે લિક્વિડિટી પ્રદાતાઓ માર્કેટની માહિતી પર કેવી પ્રતિક્રિયા આપે છે અને તેઓ ડીએક્સમાં પ્રવાહિતા પ્રદાન કરવામાં કેવી રીતે ફાયદો કરે છે.  
-
- 
-
-- [વિકેન્દ્રિત વિનિમય બજારોમાં ચક્રીય આર્બિટ્રેજ] (https://arxiv.org/pdf/2105.02784.pdf) - સારું વાંચો. આ કાગળ સૂચવે છે કે સ્માર્ટ કોન્ટ્રાક્ટ ટેકનોલોજી અને ઇથેરિયમની પ્રતિકૃતિવાળી રાજ્ય મશીન સેટિંગ સાથે, આર્સેટ્રેજ વ્યૂહરચનાઓ સીઈએક્સની તુલનામાં ડેક્સમાં સરળ અમલમાં છે.  
-
- 
-
-- [સોકે: ગ્રાઉન્ડ ટ્રુથથી માર્કેટ મેનીપ્યુલેશન સુધીના ઓરેકલ્સ] (https://arxiv.org/pdf/2106.00667.pdf) - આ સોકમાં, લેખકો ઓરેકલ્સ, શોકેસ હુમલાઓ માટેના ડિઝાઇન વિકલ્પોને વ્યવસ્થિત કરે છે, અને હુમલો ઘટાડવાની વ્યૂહરચના પર ચર્ચા કરે છે.  
-
- 
-
-- [સ્વચાલિત બજાર ઉત્પાદકોના કમ્પોઝિંગ નેટવર્ક્સ] (https://arxiv.org/pdf/2106.00083.pdf) - આ કાગળ એએમએમ કમ્પોઝિશન માટે ગાણિતિક મોડેલની દરખાસ્ત કરે છે.  
-
- 
-
- 
 
 #### ઇથેરિયમ નામ સેવા
 
- 
+- [ઇથેરિયમ નામ સેવા: સારી, ખરાબ અને અગ્લી](https://arxiv.org/pdf/2104.05185.pdf) - છતાં, કોઈ પણ હાલની કામગીરીએ આ ઉભરતી સિસ્ટમ, સુરક્ષા મુદ્દાઓ અને ENS માં ગેરવર્તનનો અભ્યાસ કર્યો નથી. . લેખકો ઇએનએસથી સંબંધિત લાખો ઇવેન્ટ લsગ્સનું વિશ્લેષણ કરીને ENS નો પ્રથમ અભ્યાસ રજૂ કરે છે.
 
-- [ઇથેરિયમ નામ સેવા: સારી, ખરાબ અને અગ્લી] (https://arxiv.org/pdf/2104.05185.pdf) - છતાં, કોઈ પણ હાલની કામગીરીએ આ ઉભરતી સિસ્ટમ, સુરક્ષા મુદ્દાઓ અને ENS માં ગેરવર્તનનો અભ્યાસ કર્યો નથી. . લેખકો ઇએનએસથી સંબંધિત લાખો ઇવેન્ટ લsગ્સનું વિશ્લેષણ કરીને ENS નો પ્રથમ અભ્યાસ રજૂ કરે છે.  
 
- 
-
- 
 
 #### નોન-ફંગિબલ ટોકન (એનએફટી):
 
- 
+- [એનએફટી ક્રાંતિનું મેપિંગ](https://arxiv.org/pdf/2106.00647.pdf) - માર્કેટ ટ્રેન્ડ, ટ્રેડ નેટવર્ક અને વિઝ્યુઅલ સુવિધાઓ.
 
-- [એનએફટી ક્રાંતિનું મેપિંગ] (https://arxiv.org/pdf/2106.00647.pdf) - માર્કેટ ટ્રેન્ડ, ટ્રેડ નેટવર્ક અને વિઝ્યુઅલ સુવિધાઓ.  
+- [ઇઆરસી ટોકન બજારોમાં nessચિત્ય](https://arxiv.org/pdf/2102.03721.pdf) - ક્રિપ્ટોકિટ્ટીઝનો એક કેસ સ્ટડી.
 
- 
+- [નોન-ફંગિબલ ટોકન: વિહંગાવલોકન, મૂલ્યાંકન, તકો અને પડકારો](https://arxiv.org/pdf/2105.07447.pdf) - આ તકનીકી અહેવાલમાં, લેખકોએ એનએફટી ઇકોસિસ્ટમ્સને કેટલાક પાસાઓમાં અન્વેષણ કર્યું છે.
 
-- [ઇઆરસી ટોકન બજારોમાં nessચિત્ય] (https://arxiv.org/pdf/2102.03721.pdf) - ક્રિપ્ટોકિટ્ટીઝનો એક કેસ સ્ટડી.  
+- [ક્રિપ્ટોર્ટ](http://cryptoart.io/) - ટોચના કલાકારો અને આર્ટવર્ક.
 
- 
+- [ક્રિપ્ટોઆર્ટપલ્સ](https://cryptoartpulse.com/) - લાઇવ વ્યૂ.
 
-- [નોન-ફંગિબલ ટોકન: વિહંગાવલોકન, મૂલ્યાંકન, તકો અને પડકારો] (https://arxiv.org/pdf/2105.07447.pdf) - આ તકનીકી અહેવાલમાં, લેખકોએ એનએફટી ઇકોસિસ્ટમ્સને કેટલાક પાસાઓમાં અન્વેષણ કર્યું છે.  
+- [પમ્પમાયગાસ](https://pumpmygas.xyz/) - તમામ મોટા એનએફટી બજારોમાં ગેસ ફીનો જીવંત અંદાજ.
 
- 
+- [નોનફંગિબલ ટ્રેકર](https://nonfungible.com/) - એનએફટી ટ્રેકર.
 
-- [ક્રિપ્ટોર્ટ] (http://cryptoart.io/) - ટોચના કલાકારો અને આર્ટવર્ક.  
+- [એનએફટીએસ ટોપ](https://cryptoslam.io) - એનએફટી રેન્કિંગ.
 
- 
 
-- [ક્રિપ્ટોઆર્ટપલ્સ] (https://cryptoartpulse.com/) - લાઇવ વ્યૂ.  
-
- 
-
-- [પમ્પમાયગાસ] (https://pumpmygas.xyz/) - તમામ મોટા એનએફટી બજારોમાં ગેસ ફીનો જીવંત અંદાજ.  
-
- 
-
-- [નોનફંગિબલ ટ્રેકર] (https://nonfungible.com/) - એનએફટી ટ્રેકર.  
-
- 
-
-- [એનએફટીએસ ટોપ] (https://cryptoslam.io) - એનએફટી રેન્કિંગ.  
-
- 
-
- 
 
 #### સ્થિર-સિક્કા:
 
- 
 
- 
 
-- [સ્ટેબલકોઇન્સ ૨.૦] (https://arxiv.org/pdf/2006.12388.pdf) - લેખકો સ્થિરકોઇન્સની આર્થિક રચનાના જોખમ આધારિત કાર્યાત્મક લાક્ષણિકતા સાથે, સ્થિરકોઇન સિદ્ધાંત માટે ધ્વનિ પાયો પ્રદાન કરવા માંગે છે.  
+- [સ્ટેબલકોઇન્સ ૨.૦](https://arxiv.org/pdf/2006.12388.pdf) - લેખકો સ્થિરકોઇન્સની આર્થિક રચનાના જોખમ આધારિત કાર્યાત્મક લાક્ષણિકતા સાથે, સ્થિરકોઇન સિદ્ધાંત માટે ધ્વનિ પાયો પ્રદાન કરવા માંગે છે.
 
- 
+- [ક્રિપ્ટોકરન્સીઝની અસ્થિરતા ઘટાડવી - એક સર્વેક્ષણના સ્ટેબલકોઇન્સ](https://arxiv.org/pdf/2103.01340.pdf) - વિવિધ પ્રકારના સ્ટેબલકોઇન્સ અને તેમની સ્થિરતા પદ્ધતિઓનું સર્વેક્ષણ કરીને ક્રિપ્ટોકરન્સીઝની અસ્થિરતા ઘટાડવામાં કેવી રીતે સ્થિરતા કરવામાં મદદ થાય છે તે અંગે લેખકો ચર્ચા કરે છે.
 
-- [ક્રિપ્ટોકરન્સીઝની અસ્થિરતા ઘટાડવી - એક સર્વેક્ષણના સ્ટેબલકોઇન્સ] (https://arxiv.org/pdf/2103.01340.pdf) - વિવિધ પ્રકારના સ્ટેબલકોઇન્સ અને તેમની સ્થિરતા પદ્ધતિઓનું સર્વેક્ષણ કરીને ક્રિપ્ટોકરન્સીઝની અસ્થિરતા ઘટાડવામાં કેવી રીતે સ્થિરતા કરવામાં મદદ થાય છે તે અંગે લેખકો ચર્ચા કરે છે.  
+- [અલ્ગોરિધમિક સ્ટેબલકોઇનની અસ્થિરતાને સમજો: મોડેલિંગ, ચકાસણી અને પ્રયોગમૂલક વિશ્લેષણ](https://arxiv.org/pdf/2101.08423.pdf) - સૈદ્ધાંતિક શક્યતાઓને સંબંધિત કરવા લેખકોએ બેસિસ કેશ સ્ટેબલકોઇનની વાસ્તવિક વ્યવહાર પ્રવૃત્તિઓ પર વ્યવસ્થિત પ્રયોગમૂલક વિશ્લેષણ કર્યું. બજાર અવલોકનો માટે.
 
- 
+- [ટી-કેશ: ટ્રાન્સફરબલ ફિયાટ બેકડ સિક્કાઓ](https://arxiv.org/pdf/2105.04485.pdf) - આ કાગળમાં લેખકો બ્લોકચેન તકનીકનો ઉપયોગ કરીને સ્થાનાંતરિત ઇલેક્ટ્રોનિક રોકડ યોજનાની દરખાસ્ત કરે છે જે વપરાશકર્તાઓને સિસ્ટમમાં સતત સિક્કાઓનો ફરીથી ઉપયોગ કરી શકે છે .
 
-- [અલ્ગોરિધમિક સ્ટેબલકોઇનની અસ્થિરતાને સમજો: મોડેલિંગ, ચકાસણી અને પ્રયોગમૂલક વિશ્લેષણ] (https://arxiv.org/pdf/2101.08423.pdf) - સૈદ્ધાંતિક શક્યતાઓને સંબંધિત કરવા લેખકોએ બેસિસ કેશ સ્ટેબલકોઇનની વાસ્તવિક વ્યવહાર પ્રવૃત્તિઓ પર વ્યવસ્થિત પ્રયોગમૂલક વિશ્લેષણ કર્યું. બજાર અવલોકનો માટે.  
 
- 
-
-- [ટી-કેશ: ટ્રાન્સફરબલ ફિયાટ બેકડ સિક્કાઓ] (https://arxiv.org/pdf/2105.04485.pdf) - આ કાગળમાં લેખકો બ્લોકચેન તકનીકનો ઉપયોગ કરીને સ્થાનાંતરિત ઇલેક્ટ્રોનિક રોકડ યોજનાની દરખાસ્ત કરે છે જે વપરાશકર્તાઓને સિસ્ટમમાં સતત સિક્કાઓનો ફરીથી ઉપયોગ કરી શકે છે .  
-
- 
-
- 
 
 #### સામાન્ય માહિતી:
 
- 
 
- 
 
-- [ઇથેરિયમ નેટવર્કનું એક મોટું ડેટા વિશ્લેષણ: બ્લોકચેનથી ગૂગલ ટ્રેન્ડ્સ સુધી] (https://arxiv.org/pdf/2104.01764.pdf) - ક્રિપ્ટો કિંમતો અને શોધ વલણોનું વિશ્લેષણ મોટા ખેલાડીઓનું અસ્તિત્વ સૂચવે છે (અને નિયમિત વપરાશકર્તાઓ નહીં), કિંમતોમાં ઘટાડા પછી બજારમાં હેરફેર કરે છે.  
+- [ઇથેરિયમ નેટવર્કનું એક મોટું ડેટા વિશ્લેષણ: બ્લોકચેનથી ગૂગલ ટ્રેન્ડ્સ સુધી](https://arxiv.org/pdf/2104.01764.pdf) - ક્રિપ્ટો કિંમતો અને શોધ વલણોનું વિશ્લેષણ મોટા ખેલાડીઓનું અસ્તિત્વ સૂચવે છે (અને નિયમિત વપરાશકર્તાઓ નહીં), કિંમતોમાં ઘટાડા પછી બજારમાં હેરફેર કરે છે.
 
- 
+- [અણુ અને સ્કેલેબલ ટ્રેડિંગ માટે ડીએલટી આધારિત સ્માર્ટ કરાર આર્કિટેક્ચર](https://arxiv.org/pdf/2105.02937.pdf) - લેખકોએ એક અણુ, સ્કેલેબલ અને ગોપનીયતા-જાળવણી પ્રોટોકોલનો પ્રસ્તાવ મૂક્યો છે જે સુરક્ષિત અને સક્ષમ બનાવે છે. ગતિશીલ સુધારાઓ. તે પછી સ્માર્ટ કરાર આધારિત ક્રેડિટ-નોંધ સિસ્ટમ (સી.એન.એસ.) નો વિકાસ કરો જે સહભાગીઓને સ્ટેટ ચેનલ પ્રારંભિકરણ પહેલાં ભંડોળને લ lockક કરવાની મંજૂરી આપે છે, જે રાહત અને કાર્યક્ષમતામાં વધારો કરે છે.
 
-- [અણુ અને સ્કેલેબલ ટ્રેડિંગ માટે ડીએલટી આધારિત સ્માર્ટ કરાર આર્કિટેક્ચર] (https://arxiv.org/pdf/2105.02937.pdf) - લેખકોએ એક અણુ, સ્કેલેબલ અને ગોપનીયતા-જાળવણી પ્રોટોકોલનો પ્રસ્તાવ મૂક્યો છે જે સુરક્ષિત અને સક્ષમ બનાવે છે. ગતિશીલ સુધારાઓ. તે પછી સ્માર્ટ કરાર આધારિત ક્રેડિટ-નોંધ સિસ્ટમ (સી.એન.એસ.) નો વિકાસ કરો જે સહભાગીઓને સ્ટેટ ચેનલ પ્રારંભિકરણ પહેલાં ભંડોળને લ lockક કરવાની મંજૂરી આપે છે, જે રાહત અને કાર્યક્ષમતામાં વધારો કરે છે.  
+- [ઇથરમ ડેટા સ્ટોર્સનું અન્વેષણ: એક કિંમત અને પર્ફોર્મન્સ સરખામણી](https://arxiv.org/pdf/2105.10520.pdf) -આ કાર્યમાં, લેખકો ઇટીએચ એપ્લિકેશન્સ માટે ડેટા મેનેજમેન્ટના અભિગમોના વ્યાપક સમૂહની તપાસ કરે છે અને સંકળાયેલ ખર્ચની આકારણી કરે છે. ગેસ તેમજ પુનrieપ્રાપ્તિ કામગીરી.
 
- 
+- [બ્લોકચેન ગવર્નન્સ અંગેની એક વ્યવસ્થિત સાહિત્ય સમીક્ષા](https://arxiv.org/pdf/2105.05460.pdf) - આ અભ્યાસ 5W1H પ્રશ્નો દ્વારા બ્લોકચેન શાસનની વિસ્તૃત તપાસ કરે છે.
 
-- [ઇથરમ ડેટા સ્ટોર્સનું અન્વેષણ: એક કિંમત અને પર્ફોર્મન્સ સરખામણી] (https://arxiv.org/pdf/2105.10520.pdf) -આ કાર્યમાં, લેખકો ઇટીએચ એપ્લિકેશન્સ માટે ડેટા મેનેજમેન્ટના અભિગમોના વ્યાપક સમૂહની તપાસ કરે છે અને સંકળાયેલ ખર્ચની આકારણી કરે છે. ગેસ તેમજ પુનrieપ્રાપ્તિ કામગીરી.  
+- [બ્લોકચેન એનાલિટિક્સ માટેનું એક સામાન્ય માળખું](https://arxiv.org/pdf/1707.01021.pdf) - લેખકો બિટકોઇન ઇથેરિયમ પર ડેટા એનાલિટિક્સને ટેકો આપતા સામાન્ય હેતુવાળા માળખાને પ્રસ્તાવિત કરે છે - તે અન્યના ડેટા સાથેના બ્લોક ડેટાને એકીકૃત કરવાની મંજૂરી આપે છે. સ્ત્રોતો, અને ડેટાબેઝમાં તેમને ગોઠવવા માટે.
 
- 
+- [એએમઆર: સ્વાર્થી સિક્કા મિક્સર ગોપનીયતા સાથે પુરસ્કાર વિતરણને સાચવી રહ્યા છે](https://arxiv.org/pdf/2010.01056.pdf) - આ કાર્યમાં, લેખકોએ પ્રથમ સેન્સરશીપ લવચીક મિક્સરની દરખાસ્ત કરી છે, જે તેના વપરાશકર્તાઓને ગોપનીયતામાં પુરસ્કાર આપી શકે છે- સિસ્ટમમાં ભાગ લેવા માટેની રીત સાચવી રાખવી.
 
-- [બ્લોકચેન ગવર્નન્સ અંગેની એક વ્યવસ્થિત સાહિત્ય સમીક્ષા] (https://arxiv.org/pdf/2105.05460.pdf) - આ અભ્યાસ 5W1H પ્રશ્નો દ્વારા બ્લોકચેન શાસનની વિસ્તૃત તપાસ કરે છે.  
+- [બ્લોકચેન ડેટા ગોપનીયતા સોલ્યુશન્સની તકનીકી સમીક્ષા](https://arxiv.org/pdf/2105.01316.pdf) - આ રિપોર્ટનો હેતુ હાલની એન્ટરપ્રાઇઝ બ્લોકચેન તકનીકીઓની સમીક્ષા કરવાનો છે: ઇઓએસઆઈઓ સંચાલિત સિસ્ટમો, હાયપરલેડર ફેબ્રિક અને બેસુ, સંમતિ કોરમ, આર 3 કોર્ડા અને અર્ન્સ્ટ અને યંગ્સ નાઇટફfallલ.
 
- 
+- [બ્લોકચેન સિસ્ટમો, તકનીકો અને એપ્લિકેશનો: એ મેથોડોલોજી પર્સપેક્ટિવ](https://arxiv.org/pdf/2105.03572.pdf) - પ્રથમ, આ લેખ બ્લ blockકચેન કેવી રીતે કાર્ય કરે છે, સંશોધન પ્રવૃત્તિ અને પડકાર રજૂ કરે છે, અને તેમાં સમાવિષ્ટ રોડમેપનું ચિત્રણ કરે છે. લાક્ષણિક બ્લોકચેન સાથેના ક્લાસિક પદ્ધતિઓનો ઉપયોગ કેસ અને વિષયોમાં થાય છે. બીજું, બ્લોકચેન સિસ્ટમમાં, સ્ટોક stસ્ટીક પ્રક્રિયા કેવી રીતે અપનાવવી, ગેમ સિદ્ધાંત, optimપ્ટિમાઇઝેશન, મશીન લર્નિંગ અને ક્રિપ્ટોગ્રાફીનો અભ્યાસ કરવા માટે બ્લોકચેન ચાલી રહેલ પ્રક્રિયા અને ડિઝાઇન બ્લોકચેન પ્રોટોકોલ / એલ્ગોરિધમ વિગતમાં ચર્ચા કરવામાં આવી છે.
 
-- [બ્લોકચેન એનાલિટિક્સ માટેનું એક સામાન્ય માળખું] (https://arxiv.org/pdf/1707.01021.pdf) - લેખકો બિટકોઇન ઇથેરિયમ પર ડેટા એનાલિટિક્સને ટેકો આપતા સામાન્ય હેતુવાળા માળખાને પ્રસ્તાવિત કરે છે - તે અન્યના ડેટા સાથેના બ્લોક ડેટાને એકીકૃત કરવાની મંજૂરી આપે છે. સ્ત્રોતો, અને ડેટાબેઝમાં તેમને ગોઠવવા માટે.  
+- [એથના: એથેરિયમ બ્લ Blockકચેનનાં અંતર્ગત પીઅર-ટુ-પીઅર નેટવર્કનું વિશ્લેષણ](https://arxiv.org/pdf/2010.01373.pdf) - એથેના નવીન પદ્ધતિનો અમલ કરે છે જે ઇથેરિયમ નોડ્સની ડિગ્રીને સચોટ રીતે માપે છે.
 
- 
+- [બ્લોકચેન સોશ્યલ નેટવર્કમાં કમ્યુનિટિ ડિટેક્શન](https://arxiv.org/pdf/2101.06406.pdf) - ગ્રાફ પર નીચા-રેન્ક સંકેતો માટે રચાયેલ એક નવલકથા સમુદાય તપાસ અલ્ગોરિધમનો ઉપયોગકર્તાના આધારે વપરાશકર્તાઓના સમુદાયો શોધવામાં મદદ કરી શકે છે. ટોકન સબ્સ્ક્રિપ્શન.
 
-- [એએમઆર: સ્વાર્થી સિક્કા મિક્સર ગોપનીયતા સાથે પુરસ્કાર વિતરણને સાચવી રહ્યા છે] (https://arxiv.org/pdf/2010.01056.pdf) - આ કાર્યમાં, લેખકોએ પ્રથમ સેન્સરશીપ લવચીક મિક્સરની દરખાસ્ત કરી છે, જે તેના વપરાશકર્તાઓને ગોપનીયતામાં પુરસ્કાર આપી શકે છે- સિસ્ટમમાં ભાગ લેવા માટેની રીત સાચવી રાખવી.  
+- [વાયરલેસ બ્લોકચેન નેટવર્કમાં બ્લોક એક્સેસ કંટ્રોલ: ડિઝાઇન, મોડેલિંગ અને એનાલિસિસ](https://arxiv.org/pdf/2104.13144.pdf) - પરિણામો દર્શાવે છે કે બીએસી અભિગમ નેટવર્કને ઉચ્ચ ટ્રાંઝેક્શન થ્રુપુટ પ્રાપ્ત કરવામાં મદદ કરશે જ્યારે સુધારણા કરશે અવરોધિત વપરાશ અને બચત ગણતરી શક્તિ. દરમિયાન, ટ્રાન્ઝેક્શન થ્રુપુટ અને બ્લોકના ઉપયોગ વચ્ચેનો વેપાર-પ્રદર્શન દર્શાવવામાં આવે છે, જે બ્લોકચેનની વ્યવહારિક જમાવટ માટે માર્ગદર્શન તરીકે કાર્ય કરી શકે છે.
 
- 
+- [બ્લોકચેન અને ડિસ્ટ્રિબ્યુટેડ લેજર ટેકનોલોજી માટેના બાહ્ય કowલ્સ તરફ](https://arxiv.org/pdf/2105.10399.pdf) - આ કાગળના લેખકો બતાવે છે કે આ માન્યતા એવી પદ્ધતિનું નિદર્શન કરીને પૂર્વ-કલ્પના કરે છે કે જે બ્લોકચેનને સક્ષમ કરે છે અને વહેંચાયેલ લ ledજર્જ તકનીકોને સક્ષમ બનાવે છે બાહ્ય સિસ્ટમોને જ બ્લોકચેન / ડીએલટીથી શરૂ કરેલ ક callsલ્સ કરો.
 
-- [બ્લોકચેન ડેટા ગોપનીયતા સોલ્યુશન્સની તકનીકી સમીક્ષા] (https://arxiv.org/pdf/2105.01316.pdf) - આ રિપોર્ટનો હેતુ હાલની એન્ટરપ્રાઇઝ બ્લોકચેન તકનીકીઓની સમીક્ષા કરવાનો છે: ઇઓએસઆઈઓ સંચાલિત સિસ્ટમો, હાયપરલેડર ફેબ્રિક અને બેસુ, સંમતિ કોરમ, આર 3 કોર્ડા અને અર્ન્સ્ટ અને યંગ્સ નાઇટફfallલ.  
+- [બ્લોકચેન સિસ્ટમો અને એપ્લિકેશનોનું સંચાલન: બ્લોકચેન ગોઠવણીઓ માટેનું એક પ્રક્રિયા મોડેલ](https://arxiv.org/pdf/2105.02118.pdf) - લેખકો ચાર બ્લોકચેન પ્રોજેક્ટ્સ પર સૂચિત બ્લોકચેન ગોઠવણી પ્રક્રિયા મોડેલની લાગુ થવાની રજૂઆત કરે છે.
 
- 
+- [સતત કાર્ય બજારના નિર્માતાઓ માટે શ્રેષ્ઠ ફીઝ પરની નોંધ](https://arxiv.org/pdf/2105.13510.pdf) - લેખકો ફ્રેમવર્ક રજૂ કરે છે જેનો ઉપયોગ ભૂતકાળના વેપાર ડેટાનો ઉપયોગ કરીને વાસ્તવિક વિશ્વના પૂલ માટે શ્રેષ્ઠ ફીની ગણતરી માટે થઈ શકે છે.
 
-- [બ્લોકચેન સિસ્ટમો, તકનીકો અને એપ્લિકેશનો: એ મેથોડોલોજી પર્સપેક્ટિવ] (https://arxiv.org/pdf/2105.03572.pdf) - પ્રથમ, આ લેખ બ્લ blockકચેન કેવી રીતે કાર્ય કરે છે, સંશોધન પ્રવૃત્તિ અને પડકાર રજૂ કરે છે, અને તેમાં સમાવિષ્ટ રોડમેપનું ચિત્રણ કરે છે. લાક્ષણિક બ્લોકચેન સાથેના ક્લાસિક પદ્ધતિઓનો ઉપયોગ કેસ અને વિષયોમાં થાય છે. બીજું, બ્લોકચેન સિસ્ટમમાં, સ્ટોક stસ્ટીક પ્રક્રિયા કેવી રીતે અપનાવવી, ગેમ સિદ્ધાંત, optimપ્ટિમાઇઝેશન, મશીન લર્નિંગ અને ક્રિપ્ટોગ્રાફીનો અભ્યાસ કરવા માટે બ્લોકચેન ચાલી રહેલ પ્રક્રિયા અને ડિઝાઇન બ્લોકચેન પ્રોટોકોલ / એલ્ગોરિધમ વિગતમાં ચર્ચા કરવામાં આવી છે.  
+- [ઇવોલ્યુશનરી ગેમ થિયરીનો ઉપયોગ કરીને બ્લોકચેન્સ માટેના પુરસ્કાર મિકેનિઝમ](https://arxiv.org/pdf/2104.05849.pdf) - આ પેપરમાં, લેખકો એક એવોર્ડ મિકેનિઝમ ફ્રેમવર્ક વિકસાવે છે જે ઘણાં પી.ઓ.એસ. બ્લોકચેન્સને લાગુ પડે છે.
 
- 
+- [સ્માર્ટ ટ્રાન્ઝિશનનો સારાંશ અપ](https://arxiv.org/pdf/2105.07663.pdf) - આ પેપરમાં, લેખકો ફર્સ્ટ-orderર્ડર લોજિકનું સામાન્યકરણ રજૂ કરે છે જે બેલેન્સની અનબાઉન્ડ રકમને વ્યક્ત કરી શકે છે.
 
-- [એથના: એથેરિયમ બ્લ Blockકચેનનાં અંતર્ગત પીઅર-ટુ-પીઅર નેટવર્કનું વિશ્લેષણ] (https://arxiv.org/pdf/2010.01373.pdf) - એથેના નવીન પદ્ધતિનો અમલ કરે છે જે ઇથેરિયમ નોડ્સની ડિગ્રીને સચોટ રીતે માપે છે.  
+- [સ+ફ્ટવેર સ્ટાર્ટઅપ્સ માટે 100+ મેટ્રિક્સ - મલ્ટિ-વોકલ લિટરરેચર રિવ્યૂ](https://arxiv.org/pdf/1901.04819.pdf) - મેટ્રિક્સના રૂપમાં ડેટાનો ઉપયોગ કરવો એ અનિશ્ચિતતા વચ્ચે યોગ્ય નિર્ણય લેવામાં સ softwareફ્ટવેર સ્ટાર્ટઅપ્સને મદદ કરી શકે છે. અને મર્યાદિત સંસાધનો.
 
- 
+- [બ્લોકચેન નેટવર્ક્સ: બિટકોઇન , મોનેરો, ઝેકેશ, ઇથેરિયમ, લહેરિયું અને આઇઓટીએના ડેટા સ્ટ્રક્ચર્સ ](https://arxiv.org/pdf/2103.08712.pdf) - લેખકો ચર્ચા કરે છે કે કેવી રીતે બ્લોકચેન ડેટાને વિવિધ પ્રકારનાં નેટવર્ક્સ તરીકે એબ્સ્ટ્રેક્ટ કરી શકાય છે, અને માળખામાં આંતરદૃષ્ટિ મેળવવા માટે નેટવર્ક એબ્સ્ટ્રેક્શન્સ કેવી રીતે ઉપયોગમાં લેવાય છે.
 
-- [બ્લોકચેન સોશ્યલ નેટવર્કમાં કમ્યુનિટિ ડિટેક્શન] (https://arxiv.org/pdf/2101.06406.pdf) - ગ્રાફ પર નીચા-રેન્ક સંકેતો માટે રચાયેલ એક નવલકથા સમુદાય તપાસ અલ્ગોરિધમનો ઉપયોગકર્તાના આધારે વપરાશકર્તાઓના સમુદાયો શોધવામાં મદદ કરી શકે છે. ટોકન સબ્સ્ક્રિપ્શન.  
-
- 
-
-- [વાયરલેસ બ્લોકચેન નેટવર્કમાં બ્લોક એક્સેસ કંટ્રોલ: ડિઝાઇન, મોડેલિંગ અને એનાલિસિસ] (https://arxiv.org/pdf/2104.13144.pdf) - પરિણામો દર્શાવે છે કે બીએસી અભિગમ નેટવર્કને ઉચ્ચ ટ્રાંઝેક્શન થ્રુપુટ પ્રાપ્ત કરવામાં મદદ કરશે જ્યારે સુધારણા કરશે અવરોધિત વપરાશ અને બચત ગણતરી શક્તિ. દરમિયાન, ટ્રાન્ઝેક્શન થ્રુપુટ અને બ્લોકના ઉપયોગ વચ્ચેનો વેપાર-પ્રદર્શન દર્શાવવામાં આવે છે, જે બ્લોકચેનની વ્યવહારિક જમાવટ માટે માર્ગદર્શન તરીકે કાર્ય કરી શકે છે.  
-
- 
-
-- [બ્લોકચેન અને ડિસ્ટ્રિબ્યુટેડ લેજર ટેકનોલોજી માટેના બાહ્ય કowલ્સ તરફ] (https://arxiv.org/pdf/2105.10399.pdf) - આ કાગળના લેખકો બતાવે છે કે આ માન્યતા એવી પદ્ધતિનું નિદર્શન કરીને પૂર્વ-કલ્પના કરે છે કે જે બ્લોકચેનને સક્ષમ કરે છે અને વહેંચાયેલ લ ledજર્જ તકનીકોને સક્ષમ બનાવે છે બાહ્ય સિસ્ટમોને જ બ્લોકચેન / ડીએલટીથી શરૂ કરેલ ક callsલ્સ કરો.  
-
- 
-
-- [બ્લોકચેન સિસ્ટમો અને એપ્લિકેશનોનું સંચાલન: બ્લોકચેન ગોઠવણીઓ માટેનું એક પ્રક્રિયા મોડેલ] (https://arxiv.org/pdf/2105.02118.pdf) - લેખકો ચાર બ્લોકચેન પ્રોજેક્ટ્સ પર સૂચિત બ્લોકચેન ગોઠવણી પ્રક્રિયા મોડેલની લાગુ થવાની રજૂઆત કરે છે.  
-
- 
-
-- [સતત કાર્ય બજારના નિર્માતાઓ માટે શ્રેષ્ઠ ફીઝ પરની નોંધ] (https://arxiv.org/pdf/2105.13510.pdf) - લેખકો ફ્રેમવર્ક રજૂ કરે છે જેનો ઉપયોગ ભૂતકાળના વેપાર ડેટાનો ઉપયોગ કરીને વાસ્તવિક વિશ્વના પૂલ માટે શ્રેષ્ઠ ફીની ગણતરી માટે થઈ શકે છે.  
-
- 
-
-- [ઇવોલ્યુશનરી ગેમ થિયરીનો ઉપયોગ કરીને બ્લોકચેન્સ માટેના પુરસ્કાર મિકેનિઝમ] (https://arxiv.org/pdf/2104.05849.pdf) - આ પેપરમાં, લેખકો એક એવોર્ડ મિકેનિઝમ ફ્રેમવર્ક વિકસાવે છે જે ઘણાં પી.ઓ.એસ. બ્લોકચેન્સને લાગુ પડે છે.  
-
- 
-
-- [સ્માર્ટ ટ્રાન્ઝિશનનો સારાંશ અપ] (https://arxiv.org/pdf/2105.07663.pdf) - આ પેપરમાં, લેખકો ફર્સ્ટ-orderર્ડર લોજિકનું સામાન્યકરણ રજૂ કરે છે જે બેલેન્સની અનબાઉન્ડ રકમને વ્યક્ત કરી શકે છે.  
-
- 
-
-- [સ+ફ્ટવેર સ્ટાર્ટઅપ્સ માટે 100+ મેટ્રિક્સ - મલ્ટિ-વોકલ લિટરરેચર રિવ્યૂ] (https://arxiv.org/pdf/1901.04819.pdf) - મેટ્રિક્સના રૂપમાં ડેટાનો ઉપયોગ કરવો એ અનિશ્ચિતતા વચ્ચે યોગ્ય નિર્ણય લેવામાં સ softwareફ્ટવેર સ્ટાર્ટઅપ્સને મદદ કરી શકે છે. અને મર્યાદિત સંસાધનો.  
-
- 
-
-- [બ્લોકચેન નેટવર્ક્સ: બિટકોઇન , મોનેરો, ઝેકેશ, ઇથેરિયમ, લહેરિયું અને આઇઓટીએના ડેટા સ્ટ્રક્ચર્સ ] (https://arxiv.org/pdf/2103.08712.pdf) - લેખકો ચર્ચા કરે છે કે કેવી રીતે બ્લોકચેન ડેટાને વિવિધ પ્રકારનાં નેટવર્ક્સ તરીકે એબ્સ્ટ્રેક્ટ કરી શકાય છે, અને માળખામાં આંતરદૃષ્ટિ મેળવવા માટે નેટવર્ક એબ્સ્ટ્રેક્શન્સ કેવી રીતે ઉપયોગમાં લેવાય છે.    
-
- 
-
-- [વિકેન્દ્રિત ફાઇનાન્સ: બ્લોકચેન- અને સ્માર્ટ કરાર આધારિત-નાણાકીય બજારો પર] (https://research.stlouisfed.org/publications/review/2021/02/05/ વિકેન્દ્રિત- ફાઇનાન્સ-on- blockchain- અને- સ્માર્ટ- નિયંત્રણ -બેસ્ડ-ફાઇનાન્સિયલ-બજારો) - ફેબિયન સ્કાર દ્વારા લખાયેલ, તકનીકી વિગતો સાથે પરંતુ ડાયજેસ્ટેબલ ફોર્મેટમાં બ્લોકચેન આધારિત બજારોની ઝાંખી આપે છે; જગ્યા પર નવા આવતા માટે મહાન કાગળ.  
-
- 
+- [વિકેન્દ્રિત ફાઇનાન્સ: બ્લોકચેન- અને સ્માર્ટ કરાર આધારિત-નાણાકીય બજારો પર](https://research.stlouisfed.org/publications/review/2021/02/05/ વિકેન્દ્રિત- ફાઇનાન્સ-on- blockchain- અને- સ્માર્ટ- નિયંત્રણ -બેસ્ડ-ફાઇનાન્સિયલ-બજારો) - ફેબિયન સ્કાર દ્વારા લખાયેલ, તકનીકી વિગતો સાથે પરંતુ ડાયજેસ્ટેબલ ફોર્મેટમાં બ્લોકચેન આધારિત બજારોની ઝાંખી આપે છે; જગ્યા પર નવા આવતા માટે મહાન કાગળ.
 
 #### સાઇડ-સાંકળો
 
- 
+- [પીઓએ નેટવર્ક](https://www.poa.network/)
 
-- [પીઓએ નેટવર્ક] (https://www.poa.network/)  
+- [પીઓએ બ્રિજ](https://bridge.poa.net/)
 
-- [પીઓએ બ્રિજ] (https://bridge.poa.net/)  
+- [પીઓએ બ્રિજ UI](https://github.com/poanetwork/bridge-ui)
 
-- [પીઓએ બ્રિજ UI] (https://github.com/poanetwork/bridge-ui)  
+- [પી.ઓ.એ. બ્રિજ કરારો](https://github.com/poanetwork/poa-bridge-c કરારો)
 
-- [પી.ઓ.એ. બ્રિજ કરારો] (https://github.com/poanetwork/poa-bridge-c કરારો)  
+- [લૂમ નેટવર્ક](https://github.com / લૂમનેટવર્ક)
 
-- [લૂમ નેટવર્ક] (https://github.com / લૂમનેટવર્ક)  
+- [મેટિક નેટવર્ક](https://docs.matic.network/)
 
-- [મેટિક નેટવર્ક] (https://docs.matic.network/)  
 
- 
-
- 
 
 #### EIP - 1559
 
- 
+- [EIP-1559 ઇથેરિયમ ફી માર્કેટનું ગતિશીલ વિશ્લેષણ](https://arxiv.org/pdf/2102.10567.pdf) - લેખકો રમતના સિદ્ધાંત અને ટૂલ્સના સંયોજન દ્વારા પરિણામી ફી માર્કેટ ગતિશીલ પદ્ધતિનું સંપૂર્ણ વિશ્લેષણ કરે છે. ગતિશીલ સિસ્ટમો.
 
-- [EIP-1559 ઇથેરિયમ ફી માર્કેટનું ગતિશીલ વિશ્લેષણ] (https://arxiv.org/pdf/2102.10567.pdf) - લેખકો રમતના સિદ્ધાંત અને ટૂલ્સના સંયોજન દ્વારા પરિણામી ફી માર્કેટ ગતિશીલ પદ્ધતિનું સંપૂર્ણ વિશ્લેષણ કરે છે. ગતિશીલ સિસ્ટમો.  
+- [EIP1559 બેસ્ફીઝના સ્ટોક્સ્ટિક ગુણધર્મો](https://arxiv.org/pdf/2105.03521.pdf) - લેખકોએ ગેસના ભાવમાં વધઘટ વધારવા સ્થિરતા લાવવા માટે વિકસિત ઇથેરિયમની નવી કિંમતોની પદ્ધતિ સમજાવી.
 
- 
+- [ઇથેરિયમ બ્લોકચેન માટે ટ્રાન્ઝેક્શન ફી મિકેનિઝમ ડિઝાઇન: EIP-1559 નું આર્થિક વિશ્લેષણ](https://arxiv.org/pdf/2012.00854.pdf) - આ અહેવાલમાં રમત-સૈદ્ધાંતિક શક્તિઓ અને દરખાસ્તની નબળાઇઓનું મૂલ્યાંકન અને સંશોધન કેટલાક વૈકલ્પિક ડિઝાઇન.
 
-- [EIP1559 બેસ્ફીઝના સ્ટોક્સ્ટિક ગુણધર્મો] (https://arxiv.org/pdf/2105.03521.pdf) - લેખકોએ ગેસના ભાવમાં વધઘટ વધારવા સ્થિરતા લાવવા માટે વિકસિત ઇથેરિયમની નવી કિંમતોની પદ્ધતિ સમજાવી.  
 
- 
-
-- [ઇથેરિયમ બ્લોકચેન માટે ટ્રાન્ઝેક્શન ફી મિકેનિઝમ ડિઝાઇન: EIP-1559 નું આર્થિક વિશ્લેષણ] (https://arxiv.org/pdf/2012.00854.pdf) - આ અહેવાલમાં રમત-સૈદ્ધાંતિક શક્તિઓ અને દરખાસ્તની નબળાઇઓનું મૂલ્યાંકન અને સંશોધન કેટલાક વૈકલ્પિક ડિઝાઇન.  
-
- 
-
- 
 
 #### ઇથેરિયમ 2.0
 
- 
 
- 
 
-- [બીકોન્ચા] (https://beaconcha.in/)  
+- [બીકોન્ચા](https://beaconcha.in/)
 
-- [બીકોન્સન] (https://beaconscan.com/)  
+- [બીકોન્સન](https://beaconscan.com/)
 
-- [ઇથેરિયમ 2.0 આંકડા] (https://eth2stats.io/)  
+- [ઇથેરિયમ 2.0 આંકડા](https://eth2stats.io/)
 
-- [ઇથેરિયમ 2.0 ડોક્સ] (https://docs.ethhub.io/ethereum-roadmap/ethereum-2.0/eth-2.0-phases/)  
+- [ઇથેરિયમ 2.0 ડોક્સ](https://docs.ethhub.io/ethereum-roadmap/ethereum-2.0/eth-2.0-phases/)
 
-- [ઇથેરિયમ ૨.૦ ક્લાયંટ] (https://docs.ethhub.io/ethereum-roadmap/ethereum-2.0/eth2.0-teams/teams-building-eth2.0/)  
+- [ઇથેરિયમ ૨.૦ ક્લાયંટ](https://docs.ethhub.io/ethereum-roadmap/ethereum-2.0/eth2.0-teams/teams-building-eth2.0/)
 
-- [ઇથેરિયમ 2.0 કાંટો] (https://eth2-fork-mon.stokes.io/)  
+- [ઇથેરિયમ 2.0 કાંટો](https://eth2-fork-mon.stokes.io/)
 
- 
 
- 
 
 #### MEV - મહત્તમ એક્સ્ટ્રેક્ટેબલ મૂલ્ય / ખાણિયો એક્સ્ટ્રેક્ટેબલ મૂલ્ય:
 
- 
 
- 
 
-- [બ્લોકચેન એક્સ્ટ્રેક્ટેબલ મૂલ્યનું મૂલ્ય: જંગલ કેટલું અંધકારમય છે?] (Https://arxiv.org/pdf/2101.05511v2.pdf) - લેખકો પુરાવા પૂરા પાડે છે કે ખાણિયો પહેલાથી જ ખાણિયો એક્સ્ટ્રેક્ટેબલ વેલ્યુ (એમઇવી) કા extે છે, જે બ્લોકચેનને અસ્થિર બનાવી શકે છે. સંમતિ સલામતી, સંબંધિત કાર્ય બતાવ્યા પ્રમાણે.  
+- [બ્લોકચેન એક્સ્ટ્રેક્ટેબલ મૂલ્યનું મૂલ્ય: જંગલ કેટલું અંધકારમય છે?](Https://arxiv.org/pdf/2101.05511v2.pdf) - લેખકો પુરાવા પૂરા પાડે છે કે ખાણિયો પહેલાથી જ ખાણિયો એક્સ્ટ્રેક્ટેબલ વેલ્યુ (એમઇવી) કા extે છે, જે બ્લોકચેનને અસ્થિર બનાવી શકે છે. સંમતિ સલામતી, સંબંધિત કાર્ય બતાવ્યા પ્રમાણે.
 
- 
+- [ફ્લેશ બોય્ઝ 2.0: વિકેન્દ્રીત એક્સચેન્જોમાં ફ્રન્ટ્રનિંગ, ટ્રાન્ઝેક્શન ફરીથી ગોઠવવું, અને સર્વસંમતિ અસ્થિરતા](https://arxiv.org/pdf/1904.05234.pdf) - એમ.ઇ.વી. ની વિભાવના રજૂ કરે છે, આ કાર્ય મોટા, જટિલ જોખમો દ્વારા પ્રકાશિત કરે છે સ્માર્ટ કરારોમાં ટ્રાન્ઝેક્શન-ingર્ડિંગ અવલંબન અને તે રીતે કે જેમાં નાણાકીય-બજાર શોષણના પરંપરાગત સ્વરૂપો બ્લોકચેન અર્થતંત્રને અનુકૂળ અને ઘૂસી રહ્યા છે.
 
-- [ફ્લેશ બોય્ઝ 2.0: વિકેન્દ્રીત એક્સચેન્જોમાં ફ્રન્ટ્રનિંગ, ટ્રાન્ઝેક્શન ફરીથી ગોઠવવું, અને સર્વસંમતિ અસ્થિરતા] (https://arxiv.org/pdf/1904.05234.pdf) - એમ.ઇ.વી. ની વિભાવના રજૂ કરે છે, આ કાર્ય મોટા, જટિલ જોખમો દ્વારા પ્રકાશિત કરે છે સ્માર્ટ કરારોમાં ટ્રાન્ઝેક્શન-ingર્ડિંગ અવલંબન અને તે રીતે કે જેમાં નાણાકીય-બજાર શોષણના પરંપરાગત સ્વરૂપો બ્લોકચેન અર્થતંત્રને અનુકૂળ અને ઘૂસી રહ્યા છે.  
-
- 
-
-- [ફ્લેશબotsટ્સ: Eth2 માં એમઇવી] (https://hackmd.io/@flashbots/mev-in-eth2) - આ પોસ્ટમાં, લેખકો એથ 2 માં ટ્રાન્ઝેક્શનના ingર્ડરિંગનો અભ્યાસ કરે છે અને એમઇવી-સક્ષમ કરેલ સ્ટેકીંગ યિલ્ડનું વિશ્લેષણ કરે છે. પછી તેઓ શોધે છે કે એમઇવી માન્યતાપ્રાપ્ત પુરસ્કારોને નોંધપાત્ર રીતે પ્રોત્સાહન આપશે પરંતુ એથ 2 ના સહભાગીઓમાં અસમાનતાઓને મજબૂત બનાવશે. લેખકો એમએવીના ગુણાત્મક પાસાઓની પણ ચર્ચા કરે છે જેમ કે એથ 2 માં સંભવિત ગતિશીલતા જે તેના સૌથી મોટા શેરધારકો જેવા કે એક્સચેન્જો અને વેલિડેટર પુલો વચ્ચે ઉદ્ભવે છે.  
-
- 
+- [ફ્લેશબotsટ્સ: Eth2 માં એમઇવી](https://hackmd.io/@flashbots/mev-in-eth2) - આ પોસ્ટમાં, લેખકો એથ 2 માં ટ્રાન્ઝેક્શનના ingર્ડરિંગનો અભ્યાસ કરે છે અને એમઇવી-સક્ષમ કરેલ સ્ટેકીંગ યિલ્ડનું વિશ્લેષણ કરે છે. પછી તેઓ શોધે છે કે એમઇવી માન્યતાપ્રાપ્ત પુરસ્કારોને નોંધપાત્ર રીતે પ્રોત્સાહન આપશે પરંતુ એથ 2 ના સહભાગીઓમાં અસમાનતાઓને મજબૂત બનાવશે. લેખકો એમએવીના ગુણાત્મક પાસાઓની પણ ચર્ચા કરે છે જેમ કે એથ 2 માં સંભવિત ગતિશીલતા જે તેના સૌથી મોટા શેરધારકો જેવા કે એક્સચેન્જો અને વેલિડેટર પુલો વચ્ચે ઉદ્ભવે છે.
 
 #### ચર્ચા
 
- 
+- [સ્માર્ટકોન્ટ્રેક્ટ રીર્સર્ચ ફોરમ](https://www.smartcontractresearch.org)
 
-- [સ્માર્ટકોન્ટ્રેક્ટ રીર્સર્ચ ફોરમ] (https://www.smartcontractresearch.org)  
 
- 
-
- 
 
 #### હેક ઘટનાની જાણ કરવી
 
- 
+- [રેકટ ન્યૂઝ](https://rekt.eth.link/leaderboard) - વ્હિસલ બ્લોઅર્સ અને DeFi તપાસકર્તાઓ માટે સમુદાય સમક્ષ તેમની માહિતી રજૂ કરવા માટેનું અનામિક પ્લેટફોર્મ.
 
-- [રેકટ ન્યૂઝ] (https://rekt.eth.link/leaderboard) - વ્હિસલ બ્લોઅર્સ અને DeFi તપાસકર્તાઓ માટે સમુદાય સમક્ષ તેમની માહિતી રજૂ કરવા માટેનું અનામિક પ્લેટફોર્મ.  
+- [બ્લોકચેન થ્રેટ ઇન્ટેલિજન્સ](https:// blockthreat.substack.com/) - ક્રિપ્ટોકરન્સી લેન્ડસ્કેપમાં નવીનતમ સુરક્ષા સમાચાર, સાધનો, ઘટનાઓ, નબળાઈઓ અને ધમકીઓને આવરી લેતું ન્યૂઝલેટર. પણ [આ રેપોને સમર્થન આપે છે.](Https://github.com/open blocksec/ blocksec- ઘટનાઓ)
 
-- [બ્લોકચેન થ્રેટ ઇન્ટેલિજન્સ] (https:// blockthreat.substack.com/) - ક્રિપ્ટોકરન્સી લેન્ડસ્કેપમાં નવીનતમ સુરક્ષા સમાચાર, સાધનો, ઘટનાઓ, નબળાઈઓ અને ધમકીઓને આવરી લેતું ન્યૂઝલેટર. પણ [આ રેપોને સમર્થન આપે છે.] (Https://github.com/open blocksec/ blocksec- ઘટનાઓ)  
+- [બ્લોકચેન કબ્રસ્તાન](https://magoo.github.io/Blockchain-Graveyard/) - બ્લોકચેન્સ સાથે સંકળાયેલા તમામ વિશાળ સુરક્ષા ભંગ અથવા ચોરીઓની સૂચિ.
 
-- [બ્લોકચેન કબ્રસ્તાન] (https://magoo.github.io/Blockchain-Graveyard/) - બ્લોકચેન્સ સાથે સંકળાયેલા તમામ વિશાળ સુરક્ષા ભંગ અથવા ચોરીઓની સૂચિ.  
 
- 
-
- 
 
 # સાધનો સંગ્રહ
 
- 
 
- 
 
 #### ઇથેરિયમ ટૂલ્સ
 
- 
+- [એથસ્ટેટ્સ](https://ethstats.io)
 
-- [એથસ્ટેટ્સ] (https://ethstats.io)  
+- [ઇટીએચ ફોર્ક્સ](https://forkmon.ethdevops.io)
 
-- [ઇટીએચ ફોર્ક્સ] (https://forkmon.ethdevops.io)  
+- [નોડ આંકડા](https://ethernodes.org)
 
-- [નોડ આંકડા] (https://ethernodes.org)  
+- [ઇવીએમ નેટવર્ક્સ સૂચિ](https://chainid.network)
 
-- [ઇવીએમ નેટવર્ક્સ સૂચિ] (https://chainid.network)  
+- [બીઆઈપી 39 ડેરિવેશન](https://iancoleman.io/bip39)
 
-- [બીઆઈપી 39 ડેરિવેશન] (https://iancoleman.io/bip39)  
+- [વેનિટી જનરેટર](https://github.com/johguse/profanity)
 
-- [વેનિટી જનરેટર] (https://github.com/johguse/profanity)  
+- [વેબ વેનિટી જનરેટર](https://vanity-eth.tk)
 
-- [વેબ વેનિટી જનરેટર] (https://vanity-eth.tk)  
+- [વેનિટી ઇથ જનરેટર્સ](https://github.com/search?q=eth+vanity)
 
-- [વેનિટી ઇથ જનરેટર્સ] (https://github.com/search?q=eth+vanity)  
+- [FindETH](https://findeth.io)
 
-- [FindETH] (https://findeth.io)  
+- [Eth Tx ડીકોડર](https://antoncoding.github.io/eth-tx-decoder)
 
-- [Eth Tx ડીકોડર] (https://antoncoding.github.io/eth-tx-decoder)  
+- [ઇથેરિયમ ઇનપુટ ડેટા ડીકોડર](https://lab.miguelmota.com/ethereum-input-data-decoder)
 
-- [ઇથેરિયમ ઇનપુટ ડેટા ડીકોડર] (https://lab.miguelmota.com/ethereum-input-data-decoder)  
+- [ઇથેરિયમ ગેસ ચાર્ટ્સ](https://ethereumprice.org/gas)
 
-- [ઇથેરિયમ ગેસ ચાર્ટ્સ] (https://ethereumprice.org/gas)  
+- [ઇથેરિયમ ટીએક્સપૂલ આંકડા](https://txpool.zengo.com/)
 
-- [ઇથેરિયમ ટીએક્સપૂલ આંકડા] (https://txpool.zengo.com/)  
+- [ગેસ કિંમતો ડેશબોર્ડ](https://explore.duneanalytics.com/public/dashboards/qswVMdzbyiiZFdnCDSwx1jfYLOjdaokM4CSGNxsH)
 
-- [ગેસ કિંમતો ડેશબોર્ડ] (https://explore.duneanalytics.com/public/dashboards/qswVMdzbyiiZFdnCDSwx1jfYLOjdaokM4CSGNxsH)  
+- [એબીઆઇ તરફથી યુઆઈ](https://ethcontract.watch)
 
-- [એબીઆઇ તરફથી યુઆઈ] (https://ethcontract.watch)  
+- [ઓરેકલ્સ ક્લબ](https://oracles.club)
 
-- [ઓરેકલ્સ ક્લબ] (https://oracles.club)  
+- [ટીએક્સ ક Comમ્બો](https://furucombo.app)
 
-- [ટીએક્સ ક Comમ્બો] (https://furucombo.app)  
+- [ETH અથવા ERC-20 માસ-પ્રેષક](https://disperse.app)
 
-- [ETH અથવા ERC-20 માસ-પ્રેષક] (https://disperse.app)  
+- [બલ્કસેન્ડર](https://ulksender.app)
 
-- [બલ્કસેન્ડર] (https://ulksender.app)  
+- [ERC20 મેટા ટોકન રેપર](https://github.com/arcadeum/erc20-meta-token)
 
-- [ERC20 મેટા ટોકન રેપર] (https://github.com/arcadeum/erc20-meta-token)  
+- [ઇથેરિયમ ટ્રાંઝેક્શન રદ કરો](https://github.com/mds1/Cancel-Ethereum- Transferences)
 
-- [ઇથેરિયમ ટ્રાંઝેક્શન રદ કરો] (https://github.com/mds1/Cancel-Ethereum- Transferences)  
+- [ફી ડબલ્યુટીએફ કેલ્ક્યુલેટર](https://fees.wtf)
 
-- [ફી ડબલ્યુટીએફ કેલ્ક્યુલેટર] (https://fees.wtf)  
+- [ગેસ આંકડા ખર્ચ કરો](https://txn.finance)
 
-- [ગેસ આંકડા ખર્ચ કરો] (https://txn.finance)  
+- [પૂલ આંકડા](https://pools.fyi)
 
-- [પૂલ આંકડા] (https://pools.fyi)  
+- [સોલહિન્ટ](https://github.com/protofire/solhint)
 
-- [સોલહિન્ટ] (https://github.com/protofire/solhint)  
+- [સોલિયમ](https://github.com/duaraghav8/Solium)
 
-- [સોલિયમ] (https://github.com/duaraghav8/Solium)  
+- [સોલ-ટેસ્ટર](https://github.com/androlo/sol-tester)
 
-- [સોલ-ટેસ્ટર] (https://github.com/androlo/sol-tester)  
+- [નક્કરતા-કવરેજ](https://github.com/sc-forks/solity-coverage)
 
-- [નક્કરતા-કવરેજ] (https://github.com/sc-forks/solity-coverage)  
+- [ટાઇપચેન](https://github.com/ethereum-ts/TypeChain)
 
-- [ટાઇપચેન] (https://github.com/ethereum-ts/TypeChain)  
 
- 
-
- 
 
 #### પુસ્તકાલયો
 
- 
+- [ડાપ્પ-બિન](https://github.com/ethereum/dapp-bin) - ઇથેરિયમ રેપો સોલિડિટી, સર્પન્ટ અને એલએલએલમાં ઘણા સામાન્ય ડેટા સ્ટ્રક્ચર્સ અને ઉપયોગિતાઓ માટે અમલીકરણ પૂરા પાડે છે.
 
-- [ડાપ્પ-બિન] (https://github.com/ethereum/dapp-bin) - ઇથેરિયમ રેપો સોલિડિટી, સર્પન્ટ અને એલએલએલમાં ઘણા સામાન્ય ડેટા સ્ટ્રક્ચર્સ અને ઉપયોગિતાઓ માટે અમલીકરણ પૂરા પાડે છે.  
+- [સોલિડિટી કલેક્શન](https://github.com/ethereum/wiki/wiki/Solidity- સંગ્રહો) - કોડ સ્નિપેટ્સ અને ઉપયોગિતા પુસ્તકાલયોનો સંગ્રહ.
 
-- [સોલિડિટી કલેક્શન] (https://github.com/ethereum/wiki/wiki/Solidity- સંગ્રહો) - કોડ સ્નિપેટ્સ અને ઉપયોગિતા પુસ્તકાલયોનો સંગ્રહ.  
-
-- [ઓપનઝેપ્લિન] (https://openzeppelin.org/) - સુરક્ષિત સ્માર્ટ કરાર બનાવવા માટેનું ફ્રેમવર્ક.  
-
- 
+- [ઓપનઝેપ્લિન](https://openzeppelin.org/) - સુરક્ષિત સ્માર્ટ કરાર બનાવવા માટેનું ફ્રેમવર્ક.
 
 #### લોકપ્રિય સ્માર્ટ કરાર પુસ્તકાલયો
 
- 
+- [ઝેપ્પેલીન](https://github.com/OpenZeppelin/openzeppelin-contracts) - સેફમાથ અને ઓપનઝેપ્પલિન એસડીકે [લાઇબ્રેરી](https://github.com/OpenZeppelin/openzeppelin-sdk) જેવા ફરીથી ઉપયોગમાં લેવાતા સ્માર્ટ કરારો સમાવે છે. કરાર સુધારણા
 
-- [ઝેપ્પેલીન] (https://github.com/OpenZeppelin/openzeppelin-contracts) - સેફમાથ અને ઓપનઝેપ્પલિન એસડીકે [લાઇબ્રેરી] (https://github.com/OpenZeppelin/openzeppelin-sdk) જેવા ફરીથી ઉપયોગમાં લેવાતા સ્માર્ટ કરારો સમાવે છે. કરાર સુધારણા  
+- [ક્રિપ્ટોફિન-સોલિડિટી](https://github.com/cryptofinlabs/cryptofin-solity) - ઇથેરિયમ પર સુરક્ષિત અને ગેસ-કાર્યક્ષમ સ્માર્ટ કરાર બનાવવા માટે સોલિડિટી લાઇબ્રેરીઓનો સંગ્રહ.
 
-- [ક્રિપ્ટોફિન-સોલિડિટી] (https://github.com/cryptofinlabs/cryptofin-solity) - ઇથેરિયમ પર સુરક્ષિત અને ગેસ-કાર્યક્ષમ સ્માર્ટ કરાર બનાવવા માટે સોલિડિટી લાઇબ્રેરીઓનો સંગ્રહ.  
+- [મોડ્યુલર લાઇબ્રેરીઓ](https://github.com/Modular-Network/ethereum-libraries) - Ethereum વર્ચ્યુઅલ મશીનનો ઉપયોગ કરીને બ્લોકચેન્સ પર વાપરવા માટે બનાવેલ પેકેજોનું જૂથ
 
-- [મોડ્યુલર લાઇબ્રેરીઓ] (https://github.com/Modular-Network/ethereum-libraries) - Ethereum વર્ચ્યુઅલ મશીનનો ઉપયોગ કરીને બ્લોકચેન્સ પર વાપરવા માટે બનાવેલ પેકેજોનું જૂથ  
+- [ડેટટાઇમ લાઇબ્રેરી](https://github.com/bokkypoobah/BokkyPooBahsDateTimeLibrary) - ગેસ-કાર્યક્ષમ સોલિડિટી તારીખ અને સમય પુસ્તકાલય
 
-- [ડેટટાઇમ લાઇબ્રેરી] (https://github.com/bokkypoobah/BokkyPooBahsDateTimeLibrary) - ગેસ-કાર્યક્ષમ સોલિડિટી તારીખ અને સમય પુસ્તકાલય  
+- [એરેગોન](https://github.com/aragon/aragon) - DAO પ્રોટોકોલ. અપગ્રેડેબિલીટી અને શાસન પર ધ્યાન કેન્દ્રિત કરીને [એરેગોનોસ સ્માર્ટ કરારનું માળખું](https://github.com/aragon/aragonOS) સમાવે છે
 
-- [એરેગોન] (https://github.com/aragon/aragon) - DAO પ્રોટોકોલ. અપગ્રેડેબિલીટી અને શાસન પર ધ્યાન કેન્દ્રિત કરીને [એરેગોનોસ સ્માર્ટ કરારનું માળખું] (https://github.com/aragon/aragonOS) સમાવે છે  
+- [એઆરસી](https://github.com/daostack/arc) - ડીએઓ માટે operatingપરેટિંગ સિસ્ટમ અને ડીએઓ સ્ટેકનો આધાર સ્તર.
 
-- [એઆરસી] (https://github.com/daostack/arc) - ડીએઓ માટે operatingપરેટિંગ સિસ્ટમ અને ડીએઓ સ્ટેકનો આધાર સ્તર.  
+- [0x](https://github.com/0x પ્રોજેકટ) - ડીએક્સ પ્રોટોકોલ
 
-- [0x] (https://github.com/0x પ્રોજેકટ) - ડીએક્સ પ્રોટોકોલ  
+- [પુરાવા સાથે ટોકન લાઇબ્રેરીઓ](https://github.com/sec-bit/tokenlibs-with-proofs) - ટોકન કોન્ટ્રેક્ટ્સ સીઆરટીના શુદ્ધતાના પુરાવા છે. આપેલ વિશિષ્ટતાઓ અને ઉચ્ચ-સ્તરની ગુણધર્મો
 
-- [પુરાવા સાથે ટોકન લાઇબ્રેરીઓ] (https://github.com/sec-bit/tokenlibs-with-proofs) - ટોકન કોન્ટ્રેક્ટ્સ સીઆરટીના શુદ્ધતાના પુરાવા છે. આપેલ વિશિષ્ટતાઓ અને ઉચ્ચ-સ્તરની ગુણધર્મો  
+- [પ્રોવેબલ એપીઆઈ](https://github.com/provable-things/ethereum-api) - ableફ-ચેન ક્રિયાઓ, ડેટા લાવવાની અને ગણતરીની મંજૂરી આપીને પ્રોવાઇડિવ સર્વિસનો ઉપયોગ કરવા માટે કરાર પૂરા પાડે છે.
 
-- [પ્રોવેબલ એપીઆઈ] (https://github.com/provable-things/ethereum-api) - ableફ-ચેન ક્રિયાઓ, ડેટા લાવવાની અને ગણતરીની મંજૂરી આપીને પ્રોવાઇડિવ સર્વિસનો ઉપયોગ કરવા માટે કરાર પૂરા પાડે છે.  
-
-- [સોલિડિટી માટે એબીડીકે પુસ્તકાલયો] (https://github.com/abdk-consulting/abdk-libraries-solidity) - ફિક્સ્ડ પોઇન્ટ (64.64 બીટ) અને આઇઇઇ-754 સુસંગત ક્વોડ ચોકસાઇ (128 બીટ) ફ્લોટિંગ-પોઇન્ટ ગણિત પુસ્તકાલયો નક્કરતા માટે  
-
- 
+- [સોલિડિટી માટે એબીડીકે પુસ્તકાલયો](https://github.com/abdk-consulting/abdk-libraries-solidity) - ફિક્સ્ડ પોઇન્ટ (64.64 બીટ) અને આઇઇઇ-754 સુસંગત ક્વોડ ચોકસાઇ (128 બીટ) ફ્લોટિંગ-પોઇન્ટ ગણિત પુસ્તકાલયો નક્કરતા માટે
 
 #### સ્માર્ટ કરાર માટેનાં દાખલા
 
- 
+- [ડappપ્સિસ: સલામત, સરળ અને લવચીક ઇથેરિયમ કરાર બિલ્ડિંગ બ્લોક્સ](https://github.com/dapphub/dappsys)
 
-- [ડappપ્સિસ: સલામત, સરળ અને લવચીક ઇથેરિયમ કરાર બિલ્ડિંગ બ્લોક્સ] (https://github.com/dapphub/dappsys)  
+- [મેકરડાઉઓ](https://github.com/makerdao/maker-otc)
 
-- [મેકરડાઉઓ] (https://github.com/makerdao/maker-otc)  
+- [ધી ટીએઓ](https://github.com/ryepdx/the-tao)
 
-- [ધી ટીએઓ] (https://github.com/ryepdx/the-tao)  
+- [ડappપ-એ-ડે 1-10](https://steemit.com/@nikolai)
 
-- [ડappપ-એ-ડે 1-10] (https://steemit.com/@nikolai)  
+- [ડappપ-એ-ડે 11-25](https://steemit.com/@nexusdev)
 
-- [ડappપ-એ-ડે 11-25] (https://steemit.com/@nexusdev)  
+- [ઓપનઝેપ્પલિન કરારો: સોલિડિટી ભાષામાં ફરીથી વાપરી શકાય તેવું અને સુરક્ષિત સ્માર્ટ કરારનું એક ખુલ્લું માળખું.](Https://github.com/OpenZeppelin/openzeppelin-c કરારો)
 
-- [ઓપનઝેપ્પલિન કરારો: સોલિડિટી ભાષામાં ફરીથી વાપરી શકાય તેવું અને સુરક્ષિત સ્માર્ટ કરારનું એક ખુલ્લું માળખું.] (Https://github.com/OpenZeppelin/openzeppelin-c કરારો)  
+- [સુરક્ષા itsડિટ્સ સાથેની શ્રેષ્ઠ પ્રયાસો વિશેનો બ્લોગ](https://blog.openzeppelin.com/)
 
-- [સુરક્ષા itsડિટ્સ સાથેની શ્રેષ્ઠ પ્રયાસો વિશેનો બ્લોગ] (https://blog.openzeppelin.com/)  
+- [એસેમ્બલી સાથેની અદ્યતન વર્કશોપ](https://github.com/androlo/solidity-workshop)
 
-- [એસેમ્બલી સાથેની અદ્યતન વર્કશોપ] (https://github.com/androlo/solidity-workshop)  
+- [સિમ્પલ ઇથેરિયમ મલ્ટિસિગ](https://medium.com/@ChrisLundkvist/exploring-simpler-ethereum-multisig-contracts-b71020c19037) - ખાસ કરીને વિભાગ _ લાભો_
 
-- [સિમ્પલ ઇથેરિયમ મલ્ટિસિગ] (https://medium.com/@ChrisLundkvist/exploring-simpler-ethereum-multisig-contracts-b71020c19037) - ખાસ કરીને વિભાગ _ લાભો_  
+- [ક્રિપ્ટોફિન સોલિડિટી Audડિટિંગ ચેકલિસ્ટ](https://github.com/cryptofinlabs/audit-checklist) - સામાન્ય તારણોની એક સૂચિ, અને જ્યારે મેનેટનેટ લોંચ માટેના કરારનું itingડિટ કરતી વખતે ધ્યાન રાખવું તે મુદ્દાઓ.
 
-- [ક્રિપ્ટોફિન સોલિડિટી Audડિટિંગ ચેકલિસ્ટ] (https://github.com/cryptofinlabs/audit-checklist) - સામાન્ય તારણોની એક સૂચિ, અને જ્યારે મેનેટનેટ લોંચ માટેના કરારનું itingડિટ કરતી વખતે ધ્યાન રાખવું તે મુદ્દાઓ.  
+- [એરેગોનોસ: ડીએઓ, ડappપ્સ અને પ્રોટોકોલ્સ બનાવવા માટેનું સ્માર્ટ કરાર માળખું](https://hack.aragon.org/docs/aragonos-intro.html)
 
-- [એરેગોનોસ: ડીએઓ, ડappપ્સ અને પ્રોટોકોલ્સ બનાવવા માટેનું સ્માર્ટ કરાર માળખું] (https://hack.aragon.org/docs/aragonos-intro.html)  
 
- 
-
- 
 
 #### સુધારણા
 
-- [બ્લોગ વોન એલેના ડિમિટ્રોવા, દેવ એટ કોલોની.આયો] (https://blog.colony.io/author/elena/)  
+- [બ્લોગ વોન એલેના ડિમિટ્રોવા, દેવ એટ કોલોની.આયો](https://blog.colony.io/author/elena/)
 
-- [પુસ્તકાલય સંચાલિત વિકાસ] (https://blog.aragon.org/library-driven-de વિકાસment-in-solity-2bebcaf88736)  
+- [પુસ્તકાલય સંચાલિત વિકાસ](https://blog.aragon.org/library-driven-de વિકાસment-in-solity-2bebcaf88736)
 
-- [અદ્યતન સોલિડિટી કોડ જમાવટ તકનીકીઓ] (https://blog.aragon.org/advanced-solidity-code-depدام-techniques-dc032665f434/)  
+- [અદ્યતન સોલિડિટી કોડ જમાવટ તકનીકીઓ](https://blog.aragon.org/advanced-solidity-code-depدام-techniques-dc032665f434/)
 
-- [પ્રોક્સી લાઇબ્રેરીઝ પર ઓપનઝેપ્લિન] (https://blog.openzeppelin.com/proxy-libraries-in-solidity-79fbe4b970fd/)  
+- [પ્રોક્સી લાઇબ્રેરીઝ પર ઓપનઝેપ્લિન](https://blog.openzeppelin.com/proxy-libraries-in-solidity-79fbe4b970fd/)
 
- 
 
- 
 
 #### વિકાસકર્તા સાધનો
 
- 
+- [ક્રિપ્ટોફિન સોલિડિટી Audડિટિંગ ચેકલિસ્ટ](https://github.com/cryptofinlabs/audit-checklist) - સામાન્ય તારણોની એક સૂચિ, અને જ્યારે મેનેટનેટ લોંચ માટેના કરારનું itingડિટ કરતી વખતે ધ્યાન રાખવું તે મુદ્દાઓ.
 
-- [ક્રિપ્ટોફિન સોલિડિટી Audડિટિંગ ચેકલિસ્ટ] (https://github.com/cryptofinlabs/audit-checklist) - સામાન્ય તારણોની એક સૂચિ, અને જ્યારે મેનેટનેટ લોંચ માટેના કરારનું itingડિટ કરતી વખતે ધ્યાન રાખવું તે મુદ્દાઓ.  
+- [માન્યતા](https://mythx.io/) - ઇથેરિયમ વિકાસકર્તાઓ માટે સુરક્ષા ચકાસણી પ્લેટફોર્મ અને ટૂલ્સ ઇકોસિસ્ટમ
 
-- [માન્યતા] (https://mythx.io/) - ઇથેરિયમ વિકાસકર્તાઓ માટે સુરક્ષા ચકાસણી પ્લેટફોર્મ અને ટૂલ્સ ઇકોસિસ્ટમ  
+- [માયથ્રિલ](https://github.com/ConsenSys/mythril) - ઓપન સોર્સ ઇવીએમ બાયટેકોડ સુરક્ષા વિશ્લેષણ ટૂલ
 
-- [માયથ્રિલ] (https://github.com/ConsenSys/mythril) - ઓપન સોર્સ ઇવીએમ બાયટેકોડ સુરક્ષા વિશ્લેષણ ટૂલ  
+- [ઓયેન્ટે](https://github.com/melonproject/oyente) - વૈકલ્પિક સ્થિર સ્માર્ટ કરાર સુરક્ષા વિશ્લેષણ
 
-- [ઓયેન્ટે] (https://github.com/melonproject/oyente) - વૈકલ્પિક સ્થિર સ્માર્ટ કરાર સુરક્ષા વિશ્લેષણ  
+- [સિક્યોરિટી](https://securify.chainsecurity.com/) - ઇથેરિયમ સ્માર્ટ કરાર માટે સુરક્ષા સ્કેનર
 
-- [સિક્યોરિટી] (https://securify.chainsecurity.com/) - ઇથેરિયમ સ્માર્ટ કરાર માટે સુરક્ષા સ્કેનર  
+- [સ્માર્ટચેક](https://tool.smartdec.net/) - સ્થિર સ્માર્ટ કરાર સુરક્ષા સુરક્ષા વિશ્લેષક
 
-- [સ્માર્ટચેક] (https://tool.smartdec.net/) - સ્થિર સ્માર્ટ કરાર સુરક્ષા સુરક્ષા વિશ્લેષક  
+- [ઇથરપ્લે](https://github.com/crytic/ethersplay) - ઇવીએમ ડિસએસેમ્બલર
 
-- [ઇથરપ્લે] (https://github.com/crytic/ethersplay) - ઇવીએમ ડિસએસેમ્બલર  
+- [ઇવોમડીસ](https://github.com/Arachnid/evmdis) - વૈકલ્પિક ઇવીએમ ડિસએસેમ્બલર
 
-- [ઇવોમડીસ] (https://github.com/Arachnid/evmdis) - વૈકલ્પિક ઇવીએમ ડિસએસેમ્બલર  
+- [હાઇડ્રા](https://github.com/IC3Hydra/Hydra) - ક્રિપ્ટોઇકોનોમિક કોન્ટ્રાક્ટ સુરક્ષા, વિકેન્દ્રિત સુરક્ષા બounન્ટીઝ માટેની ફ્રેમવર્ક
 
-- [હાઇડ્રા] (https://github.com/IC3Hydra/Hydra) - ક્રિપ્ટોઇકોનોમિક કોન્ટ્રાક્ટ સુરક્ષા, વિકેન્દ્રિત સુરક્ષા બounન્ટીઝ માટેની ફ્રેમવર્ક  
+- [સોલગ્રાફ](https://github.com/rainorshine/solographic) - સ્માર્ટ કરાર સુરક્ષા વિશ્લેષણ માટે સોલિડિટી કંટ્રોલ ફ્લોનું વિઝ્યુઅલાઇઝ કરો
 
-- [સોલગ્રાફ] (https://github.com/rainorshine/solographic) - સ્માર્ટ કરાર સુરક્ષા વિશ્લેષણ માટે સોલિડિટી કંટ્રોલ ફ્લોનું વિઝ્યુઅલાઇઝ કરો  
+- [મantંટિકોર](https://github.com/trailofbit/manticore) - સ્માર્ટ કરારો અને દ્વિસંગીઓ પરનું પ્રતીક એક્ઝેક્યુશન ટૂલ
 
-- [મantંટિકોર] (https://github.com/trailofbit/manticore) - સ્માર્ટ કરારો અને દ્વિસંગીઓ પરનું પ્રતીક એક્ઝેક્યુશન ટૂલ  
+- [સ્લિટર](https://github.com/crytic/slither) - એક નક્કરતા સ્થિર વિશ્લેષણ માળખું
 
-- [સ્લિટર] (https://github.com/crytic/slither) - એક નક્કરતા સ્થિર વિશ્લેષણ માળખું  
+- [એડિલેડ](https://github.com/sec-bit/adelaide) - એસ.સી.સી.બી.ટી. સ્થિર વિશ્લેષણ સોલિડિટી કમ્પાઇલરમાં
 
-- [એડિલેડ] (https://github.com/sec-bit/adelaide) - એસ.સી.સી.બી.ટી. સ્થિર વિશ્લેષણ સોલિડિટી કમ્પાઇલરમાં  
+- [સોલક-વેરિફિકેશન) (https://github.com/SRI-CSL/solidity/) - સોલિડિટી સ્માર્ટ કરાર માટે મોડ્યુલર વેરિફાયર
 
-- [સોલક-વેરિફિકેશન) (https://github.com/SRI-CSL/solidity/) - સોલિડિટી સ્માર્ટ કરાર માટે મોડ્યુલર વેરિફાયર  
+- [સોલિડિટી સિક્યુરિટી બ્લ ]ગ](https://github.com/sigp/solidity-security-blog) - જાણીતા એટેક વેક્ટર અને સામાન્ય વિરોધી દાખલાઓની વિસ્તૃત સૂચિ
 
-- [સોલિડિટી સિક્યુરિટી બ્લ ]ગ] (https://github.com/sigp/solidity-security-blog) - જાણીતા એટેક વેક્ટર અને સામાન્ય વિરોધી દાખલાઓની વિસ્તૃત સૂચિ  
+- [અદ્ભુત બગડેલ ERC20 ટોકન્સ](https://github.com/sec-bit/awesome-buggy-erc20-tokens) - અસરગ્રસ્ત ટોકન્સવાળા ERC20 સ્માર્ટ કરારોમાં નબળાઈઓનો સંગ્રહ.
 
-- [અદ્ભુત બગડેલ ERC20 ટોકન્સ] (https://github.com/sec-bit/awesome-buggy-erc20-tokens) - અસરગ્રસ્ત ટોકન્સવાળા ERC20 સ્માર્ટ કરારોમાં નબળાઈઓનો સંગ્રહ.  
+- [નિ Smartશુલ્ક સ્માર્ટ કરાર સુરક્ષા Audડિટ](https://callisto.network/smart-contract-audit/) - કistલિસ્ટો નેટવર્કથી નિ smartશુલ્ક સ્માર્ટ કરાર સુરક્ષા સુરક્ષા audડિટ
 
-- [નિ Smartશુલ્ક સ્માર્ટ કરાર સુરક્ષા Audડિટ] (https://callisto.network/smart-contract-audit/) - કistલિસ્ટો નેટવર્કથી નિ smartશુલ્ક સ્માર્ટ કરાર સુરક્ષા સુરક્ષા audડિટ  
-
-- [પીએટ] (https://piet.slock.it) - વિઝ્યુઅલ સોલિડિટી આર્કિટેક્ચર વિશ્લેષક  
-
- 
+- [પીએટ](https://piet.slock.it) - વિઝ્યુઅલ સોલિડિટી આર્કિટેક્ચર વિશ્લેષક
 
 #### અગ્ર ઇથેરિયમ API
 
- 
 
- 
 
-- [Web3.js] (https://github.com/ethereum/web3.js/) - જાવાસ્ક્રિપ્ટ વેબ 3  
+- [Web3.js](https://github.com/ethereum/web3.js/) - જાવાસ્ક્રિપ્ટ વેબ 3
 
-- [Eth.js] (https://github.com/ethjs) - જાવાસ્ક્રિપ્ટ વેબ 3 વિકલ્પ  
+- [Eth.js](https://github.com/ethjs) - જાવાસ્ક્રિપ્ટ વેબ 3 વિકલ્પ
 
-- [એથર્સ.જેએસ] (https://github.com/ethers-io/ethers.js/) - જાવાસ્ક્રિપ્ટ વેબ 3 વૈકલ્પિક, ઉપયોગી ઉપયોગિતાઓ અને વletલેટ સુવિધાઓ  
+- [એથર્સ.જેએસ](https://github.com/ethers-io/ethers.js/) - જાવાસ્ક્રિપ્ટ વેબ 3 વૈકલ્પિક, ઉપયોગી ઉપયોગિતાઓ અને વletલેટ સુવિધાઓ
 
-- [લાઇટ.જેએસ] (https://github.com/paritytech/js-libs/tree/master/packages/light.js) પ્રકાશ ગ્રાહકો માટે forપ્ટિમાઇઝ કરેલ ઉચ્ચ-સ્તરની પ્રતિક્રિયાશીલ જે.એસ.  
+- [લાઇટ.જેએસ](https://github.com/paritytech/js-libs/tree/master/packages/light.js) પ્રકાશ ગ્રાહકો માટે forપ્ટિમાઇઝ કરેલ ઉચ્ચ-સ્તરની પ્રતિક્રિયાશીલ જે.એસ.
 
-- [વેબ W રેપર] (https://github.com/0xProject/0x-monorepo/tree/de વિકાસment/packages/web3-wrapper) - ટાઇપસ્ક્રિપ્ટ વેબ 3 વૈકલ્પિક  
+- [વેબ W રેપર](https://github.com/0xProject/0x-monorepo/tree/de વિકાસment/packages/web3-wrapper) - ટાઇપસ્ક્રિપ્ટ વેબ 3 વૈકલ્પિક
 
-- [Ethereumjs] (https://github.com/ethereumjs/) - ઇથેરિયમ માટે ઉપયોગિતા કાર્યોનો સંગ્રહ જેમ કે [ઇથેરમજેસ-યુટ્યુએલ] (https://github.com/ethereumjs/ethereumjs-util) અને [ઇથેરમજ્સ-ટીએક્સ ] (https://github.com/ethereumjs/ethereumjs-tx)  
+- [Ethereumjs](https://github.com/ethereumjs/) - ઇથેરિયમ માટે ઉપયોગિતા કાર્યોનો સંગ્રહ જેમ કે [ઇથેરમજેસ-યુટ્યુએલ](https://github.com/ethereumjs/ethereumjs-util) અને [ઇથેરમજ્સ-ટીએક્સ ](https://github.com/ethereumjs/ethereumjs-tx)
 
-- [અલકેમિ-વેબ3.js] (https://github.com/alchemyplatform/alchemy-web3) - જાવાસ્ક્રિપ્ટ વેબ 3 રેપર, સ્વચાલિત રીટ્રીઝ સાથે, [અલકેમિના ઉન્નત APIs] ની accessક્સેસ (https://docs.alchemyapi.io/docamentation / કીમિયો-વેબ 3 / ઉન્નત-વેબ 3-એપીઆઇ), અને મજબૂત વેબસોકેટ કનેક્શન્સ.  
+- [અલકેમિ-વેબ3.js](https://github.com/alchemyplatform/alchemy-web3) - જાવાસ્ક્રિપ્ટ વેબ 3 રેપર, સ્વચાલિત રીટ્રીઝ સાથે, [અલકેમિના ઉન્નત APIs] ની accessક્સેસ (https://docs.alchemyapi.io/docamentation / કીમિયો-વેબ 3 / ઉન્નત-વેબ 3-એપીઆઇ), અને મજબૂત વેબસોકેટ કનેક્શન્સ.
 
-- [ફ્લેક્સ-કરાર] (https://github.com/merklejerk/flex-contract) અને [ફ્લેક્સ-ઇથર] (https://github.com/merklejerk/flex-ether) - આધુનિક, શૂન્ય-ગોઠવણી, ઉચ્ચ સ્માર્ટ કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવા અને વ્યવહાર કરવા માટે -લેવેલ લાઇબ્રેરીઓ.  
+- [ફ્લેક્સ-કરાર](https://github.com/merklejerk/flex-contract) અને [ફ્લેક્સ-ઇથર](https://github.com/merklejerk/flex-ether) - આધુનિક, શૂન્ય-ગોઠવણી, ઉચ્ચ સ્માર્ટ કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવા અને વ્યવહાર કરવા માટે -લેવેલ લાઇબ્રેરીઓ.
 
-- [ઇઝ-એએસ] (https://github.com/merklejerk/ez-ens) - સરળ, શૂન્ય-રૂપરેખાંકન Ethereum નામ સેવા સરનામું ઠરાવનાર.  
+- [ઇઝ-એએસ](https://github.com/merklejerk/ez-ens) - સરળ, શૂન્ય-રૂપરેખાંકન Ethereum નામ સેવા સરનામું ઠરાવનાર.
 
-- [web3x] (https://github.com/xf00f/web3x) - વેબ3.js. નો ટાઇપસ્ક્રિપ્ટ બંદર. લાભોમાં નાના બિલ્ડ્સ અને સંપૂર્ણ પ્રકારની સલામતી શામેલ છે, જેમાં કરાર સાથે ક્રિયાપ્રતિક્રિયા કરતી વખતે શામેલ છે.  
+- [web3x](https://github.com/xf00f/web3x) - વેબ3.js. નો ટાઇપસ્ક્રિપ્ટ બંદર. લાભોમાં નાના બિલ્ડ્સ અને સંપૂર્ણ પ્રકારની સલામતી શામેલ છે, જેમાં કરાર સાથે ક્રિયાપ્રતિક્રિયા કરતી વખતે શામેલ છે.
 
-- [નેથેરિયમ] (https://github.com/Nethereum/) - ક્રોસ-પ્લેટફોર્મ ઇથેરિયમ વિકાસ ફ્રેમવર્ક  
+- [નેથેરિયમ](https://github.com/Nethereum/) - ક્રોસ-પ્લેટફોર્મ ઇથેરિયમ વિકાસ ફ્રેમવર્ક
 
-- [dfuse] (https://github.com/dfuse-io/client-js) - [dfuse Ethereum API] (https://dfuse.io) નો ઉપયોગ કરવા માટે ટાઇપસ્ક્રિપ્ટ લાઇબ્રેરી  
+- [dfuse](https://github.com/dfuse-io/client-js) - [dfuse Ethereum API](https://dfuse.io) નો ઉપયોગ કરવા માટે ટાઇપસ્ક્રિપ્ટ લાઇબ્રેરી
 
-- [ઝરમર વરસાદ] (https://github.com/truffle-box/drizzle-box) - બ્લ blockકચેનથી અગ્રને જોડવા માટે રેડક્સ લાઇબ્રેરી  
+- [ઝરમર વરસાદ](https://github.com/truffle-box/drizzle-box) - બ્લ blockકચેનથી અગ્રને જોડવા માટે રેડક્સ લાઇબ્રેરી
 
-- [એસ.ડી.કે. એસ.ડી.કે.] (https://github.com/tasitlabs/tasitsdk) - રીએક્ટ નેટીવનો ઉપયોગ કરીને મૂળ મોબાઇલ ઇથેરિયમ ડppપ્સ બનાવવા માટે જાવાસ્ક્રિપ્ટ એસ.ડી.કે.  
+- [એસ.ડી.કે. એસ.ડી.કે.](https://github.com/tasitlabs/tasitsdk) - રીએક્ટ નેટીવનો ઉપયોગ કરીને મૂળ મોબાઇલ ઇથેરિયમ ડppપ્સ બનાવવા માટે જાવાસ્ક્રિપ્ટ એસ.ડી.કે.
 
-- [યુઝમેટામાસ્ક] (https://github.com/mdtanrikulu/use-metamask) - ઇથેરિયમ -અપની પ્રોજેક્ટ્સમાં મેટામાસ્કનું સંચાલન કરવા માટે એક કસ્ટમ રિએક્ટ હૂક  
+- [યુઝમેટામાસ્ક](https://github.com/mdtanrikulu/use-metamask) - ઇથેરિયમ -અપની પ્રોજેક્ટ્સમાં મેટામાસ્કનું સંચાલન કરવા માટે એક કસ્ટમ રિએક્ટ હૂક
 
-- [વોલેટ કનેક્ટ] (https://walletconnect.org/) - વ Walલેટને ડ Dપ્સથી કનેક્ટ કરવા માટેનો પ્રોટોકોલ ખોલો  
+- [વોલેટ કનેક્ટ](https://walletconnect.org/) - વ Walલેટને ડ Dપ્સથી કનેક્ટ કરવા માટેનો પ્રોટોકોલ ખોલો
 
-- [સબપ્રોવિડર્સ] (https://0x.org/docs/tools/subprovider) - [વેબ 3-પ્રદાતા-એન્જિન] સાથે જોડાવા માટે ઉપયોગી કેટલાક ઉપયોગી સબપ્રોવિડર્સ (https://github.com/MetaMask/web3-provider- એન્જિન) (તમારા ડી.પી.એ.માં લેજર હાર્ડવેર વletલેટ સપોર્ટ ઉમેરવા માટેના લેજરસબપ્રોવિડર સહિત)  
+- [સબપ્રોવિડર્સ](https://0x.org/docs/tools/subprovider) - [વેબ 3-પ્રદાતા-એન્જિન] સાથે જોડાવા માટે ઉપયોગી કેટલાક ઉપયોગી સબપ્રોવિડર્સ (https://github.com/MetaMask/web3-provider- એન્જિન) (તમારા ડી.પી.એ.માં લેજર હાર્ડવેર વletલેટ સપોર્ટ ઉમેરવા માટેના લેજરસબપ્રોવિડર સહિત)
 
-- [ethvtx] (https://github.com/ticket721/ethvtx) - ઇથેરિયમ તૈયાર અને ફ્રેમવર્ક-અજ્ostોસ્ટીક રીડ્યુક્સ સ્ટોર ગોઠવણી. [ડsક્સ] (https://ticket721.github.io/ethvtx/)  
+- [ethvtx](https://github.com/ticket721/ethvtx) - ઇથેરિયમ તૈયાર અને ફ્રેમવર્ક-અજ્ostોસ્ટીક રીડ્યુક્સ સ્ટોર ગોઠવણી. [ડsક્સ](https://ticket721.github.io/ethvtx/)
 
-- સખત રીતે ટાઇપ - જાવાસ્ક્રિપ્ટ વિકલ્પો  
+- સખત રીતે ટાઇપ - જાવાસ્ક્રિપ્ટ વિકલ્પો
 
-- [એલ્મ-ઇથેરિયમ] (https://github.com/cmditch/elm-ethereum)  
+- [એલ્મ-ઇથેરિયમ](https://github.com/cmditch/elm-ethereum)
 
-- [પ્યોરસ્ક્રીપ્ટ-વેબ]] (https://github.com/foam/purescript-web3)  
+- [પ્યોરસ્ક્રીપ્ટ-વેબ]](https://github.com/foam/purescript-web3)
 
-- [ચેઇનઅબ્સ્ટ્રેક્શનલેયર] (https://github.com/liquality/chainabstrationlayer) - એક જ ઇન્ટરફેસનો ઉપયોગ કરીને વિવિધ બ્લોકચેન્સ (ઇથેરિયમ સહિત) સાથે વાતચીત કરો.  
+- [ચેઇનઅબ્સ્ટ્રેક્શનલેયર](https://github.com/liquality/chainabstrationlayer) - એક જ ઇન્ટરફેસનો ઉપયોગ કરીને વિવિધ બ્લોકચેન્સ (ઇથેરિયમ સહિત) સાથે વાતચીત કરો.
 
-- [ડેલ્ફેરિયમ] (https://github.com/svanas/delphereum) - ઇથેરિયમ બ્લchaકચેન માટે ડેલ્ફી ઇન્ટરફેસ જે વિન્ડોઝ, મ maકઓએસ, આઇઓએસ અને એન્ડ્રોઇડ માટે મૂળ ડીપ્પ્સના વિકાસને મંજૂરી આપે છે.  
+- [ડેલ્ફેરિયમ](https://github.com/svanas/delphereum) - ઇથેરિયમ બ્લchaકચેન માટે ડેલ્ફી ઇન્ટરફેસ જે વિન્ડોઝ, મ maકઓએસ, આઇઓએસ અને એન્ડ્રોઇડ માટે મૂળ ડીપ્પ્સના વિકાસને મંજૂરી આપે છે.
 
-- [ટોરસ] (https://tor.us/) - સીમલેસ ઓનબોર્ડિંગ યુએક્સ સાથે ડેપ્સ બનાવવા માટે ઓપન સોર્સિસ એસડીકે  
+- [ટોરસ](https://tor.us/) - સીમલેસ ઓનબોર્ડિંગ યુએક્સ સાથે ડેપ્સ બનાવવા માટે ઓપન સોર્સિસ એસડીકે
 
-- [ફોર્મેટીક] (https://fortomot.com/) - એક્સ્ટેંશન અથવા ડાઉનલોડ વિના વેબ 3 ડી એપ્સ બનાવવા માટે એસડીકેનો ઉપયોગ કરવો એક સરળ.  
+- [ફોર્મેટીક](https://fortomot.com/) - એક્સ્ટેંશન અથવા ડાઉનલોડ વિના વેબ 3 ડી એપ્સ બનાવવા માટે એસડીકેનો ઉપયોગ કરવો એક સરળ.
 
-- [પોર્ટિસ] (https://portis.io/) - એસડીકે સાથેનું એક ન -ન-કસ્ટોડિયલ વletલેટ જે કંઈપણ ઇન્સ્ટોલ કર્યા વિના ડીપ્પ્સ સાથે સરળ ક્રિયાપ્રતિક્રિયાને સક્ષમ કરે છે.  
+- [પોર્ટિસ](https://portis.io/) - એસડીકે સાથેનું એક ન -ન-કસ્ટોડિયલ વletલેટ જે કંઈપણ ઇન્સ્ટોલ કર્યા વિના ડીપ્પ્સ સાથે સરળ ક્રિયાપ્રતિક્રિયાને સક્ષમ કરે છે.
 
-- [ક્રિએટ-એથ-એપ્લિકેશન] (https://github.com/paulrberg/create-eth-app) - એક આદેશ સાથે ઇથેરિયમ સંચાલિત ફ્રન્ટ-એન્ડ એપ્લિકેશનો બનાવો.  
+- [ક્રિએટ-એથ-એપ્લિકેશન](https://github.com/paulrberg/create-eth-app) - એક આદેશ સાથે ઇથેરિયમ સંચાલિત ફ્રન્ટ-એન્ડ એપ્લિકેશનો બનાવો.
 
-- [સ્કેફોલ્ડ-ઇટીએચ] (https://github.com/austintgriffith/scaffold-eth) - સ્માર્ટ કરાર બાંધવા શરૂ કરવા માટે પ્રારંભિક મૈત્રીપૂર્ણ ફોર્કેબલ ગીથબ  
+- [સ્કેફોલ્ડ-ઇટીએચ](https://github.com/austintgriffith/scaffold-eth) - સ્માર્ટ કરાર બાંધવા શરૂ કરવા માટે પ્રારંભિક મૈત્રીપૂર્ણ ફોર્કેબલ ગીથબ
 
-- [સૂચિત.જેએસ] (https:// blocknative.com/notify) - તમારા વપરાશકર્તાઓને રીઅલ-ટાઇમ સૂચનાઓ પહોંચાડો. સ્પીડ-અપ્સ અને કેન્સલ્સ માટે બિલ્ટ-ઇન સપોર્ટ સાથે, બ્લોકનેટીવ નોટિફાઇ.જેઝ વપરાશકર્તાઓને વિશ્વાસ સાથે વ્યવહાર કરવામાં મદદ કરે છે. સૂચિત.જેએસ એકીકૃત કરવા માટે સરળ અને કસ્ટમાઇઝ કરવા માટે ઝડપી છે.  
-
- 
+- [સૂચિત.જેએસ](https:// blocknative.com/notify) - તમારા વપરાશકર્તાઓને રીઅલ-ટાઇમ સૂચનાઓ પહોંચાડો. સ્પીડ-અપ્સ અને કેન્સલ્સ માટે બિલ્ટ-ઇન સપોર્ટ સાથે, બ્લોકનેટીવ નોટિફાઇ.જેઝ વપરાશકર્તાઓને વિશ્વાસ સાથે વ્યવહાર કરવામાં મદદ કરે છે. સૂચિત.જેએસ એકીકૃત કરવા માટે સરળ અને કસ્ટમાઇઝ કરવા માટે ઝડપી છે.
 
 #### બેકએન્ડ ઇથેરિયમ API
 
- 
+- [Web3.py](https://github.com/ethereum/web3.py) - પાયથોન વેબ 3
 
-- [Web3.py] (https://github.com/ethereum/web3.py) - પાયથોન વેબ 3  
+- [Web3.php](https://github.com/sc0Vu/web3.php) - PHP Web3
 
-- [Web3.php] (https://github.com/sc0Vu/web3.php) - PHP Web3  
+- [એથેરિયમ-પીએચપી](https://github.com/digitaldonkey/ethereum-php) - PHP, વેબ 3
 
-- [એથેરિયમ-પીએચપી] (https://github.com/digitaldonkey/ethereum-php) - PHP, વેબ 3  
+- [Web3j](https://github.com/web3j/web3j) - જાવા વેબ 3
 
-- [Web3j] (https://github.com/web3j/web3j) - જાવા વેબ 3  
+- [નેથેરિયમ](https://nethereum.com/) - .નેટ વેબ 3
 
-- [નેથેરિયમ] (https://nethereum.com/) - .નેટ વેબ 3  
+- [Ethereum.rb](https://github.com/EthWorks/ethereum.rb) - રૂબી વેબ 3
 
-- [Ethereum.rb] (https://github.com/EthWorks/ethereum.rb) - રૂબી વેબ 3  
+- [રસ્ટ-વેબ 3](https://github.com/tomusdrw/rust-web3) - રસ્ટ વેબ 3
 
-- [રસ્ટ-વેબ 3] (https://github.com/tomusdrw/rust-web3) - રસ્ટ વેબ 3  
+- [ઇથર્સ-આરએસ](https://github.com/gakonst/ethers-rs/) - ઇથર્સ-આરએસ
 
-- [ઇથર્સ-આરએસ] (https://github.com/gakonst/ethers-rs/) - ઇથર્સ-આરએસ  
+- [Web3.hs](https://hackage.haskell.org/package/web3) - હાસ્કેલ વેબ 3
 
-- [Web3.hs] (https://hackage.haskell.org/package/web3) - હાસ્કેલ વેબ 3  
+- [KEthereum](https://github.com/komputing/KEthereum) - કોટલીન વેબ 3
 
-- [KEthereum] (https://github.com/komputing/KEthereum) - કોટલીન વેબ 3  
+- [ઇવેન્ટિયમ](https://github.com/ConsenSys/eventeum) - એથરિયમ સ્માર્ટ કોન્ટ્રાક્ટ ઇવેન્ટ્સ અને બેકએન્ડ માઇક્રો સર્વિસિસ વચ્ચેનો પુલ, જાવા માં કૌરી દ્વારા લખાયેલ
 
-- [ઇવેન્ટિયમ] (https://github.com/ConsenSys/eventeum) - એથરિયમ સ્માર્ટ કોન્ટ્રાક્ટ ઇવેન્ટ્સ અને બેકએન્ડ માઇક્રો સર્વિસિસ વચ્ચેનો પુલ, જાવા માં કૌરી દ્વારા લખાયેલ  
+- [ઇથેર્યુમેક્સ](https://github.com/mana-ethereum/ethereumex) - ઇથેરિયમ બ્લોકચેન માટે એલિક્સિર JSON-RPC ક્લાયંટ
 
-- [ઇથેર્યુમેક્સ] (https://github.com/mana-ethereum/ethereumex) - ઇથેરિયમ બ્લોકચેન માટે એલિક્સિર JSON-RPC ક્લાયંટ  
+- [એથેરિયમ-જેસનરોપીસી-ગેટવે](https://github.com/HydroProtocol/ethereum-jsonrpc-gateway) - એક ગેટવે કે જે તમને રીડન્ડન્સી અને લોડ-બેલેન્સિંગ હેતુ માટે બહુવિધ ઇથેરિયમ નોડ ચલાવવાની મંજૂરી આપે છે. ઇન્ફુરા (અથવા ટોચ પર) ના વિકલ્પ તરીકે ચલાવી શકાય છે. ગોલાંગમાં લખાયેલ.
 
-- [એથેરિયમ-જેસનરોપીસી-ગેટવે] (https://github.com/HydroProtocol/ethereum-jsonrpc-gateway) - એક ગેટવે કે જે તમને રીડન્ડન્સી અને લોડ-બેલેન્સિંગ હેતુ માટે બહુવિધ ઇથેરિયમ નોડ ચલાવવાની મંજૂરી આપે છે. ઇન્ફુરા (અથવા ટોચ પર) ના વિકલ્પ તરીકે ચલાવી શકાય છે. ગોલાંગમાં લખાયેલ.  
+- [એથકોન્ટ્રેક્ટ](https://github.com/AgileAlpha/eth_contract) - એલિક્સિરમાં ETH સ્માર્ટ કોન્ટ્રાક્ટ્સને ક્વેરી કરવામાં સહાય માટે સહાયક પદ્ધતિઓનો સમૂહ
 
-- [એથકોન્ટ્રેક્ટ] (https://github.com/AgileAlpha/eth_contract) - એલિક્સિરમાં ETH સ્માર્ટ કોન્ટ્રાક્ટ્સને ક્વેરી કરવામાં સહાય માટે સહાયક પદ્ધતિઓનો સમૂહ  
+- [ઇથેરિયમ કરાર સેવા](https://github.com/mesg-foundation/service-ethereum-contract) - તેના સરનામાં અને એબીઆઈના આધારે કોઈપણ ઇથેરિયમ કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવા માટે એક એમઇએસજી સેવા.
 
-- [ઇથેરિયમ કરાર સેવા] (https://github.com/mesg-foundation/service-ethereum-contract) - તેના સરનામાં અને એબીઆઈના આધારે કોઈપણ ઇથેરિયમ કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવા માટે એક એમઇએસજી સેવા.  
+- [ઇથેરિયમ સર્વિસ](https://github.com/mesg-foundation/service-ethereum) - ઇથેરિયમની ઇવેન્ટ્સ સાથે વાતચીત કરવા અને તેની સાથે ક્રિયાપ્રતિક્રિયા કરવા માટે એક MESG સેવા.
 
-- [ઇથેરિયમ સર્વિસ] (https://github.com/mesg-foundation/service-ethereum) - ઇથેરિયમની ઇવેન્ટ્સ સાથે વાતચીત કરવા અને તેની સાથે ક્રિયાપ્રતિક્રિયા કરવા માટે એક MESG સેવા.  
+- [માર્મો](https://marmo.io/) - ઇથેરિયમ સાથે ક્રિયાપ્રતિક્રિયાઓને સરળ બનાવવા માટે પાયથોન, જેએસ અને જાવા એસડીકે. રિલેર્સના વ્યવહાર ખર્ચને costsફલોડ માટે રિલેઅર્સનો ઉપયોગ કરે છે.
 
-- [માર્મો] (https://marmo.io/) - ઇથેરિયમ સાથે ક્રિયાપ્રતિક્રિયાઓને સરળ બનાવવા માટે પાયથોન, જેએસ અને જાવા એસડીકે. રિલેર્સના વ્યવહાર ખર્ચને costsફલોડ માટે રિલેઅર્સનો ઉપયોગ કરે છે.  
-
-- [ઇથેરિયમ લgingગિંગ ફ્રેમવર્ક] (https://bitbucket.csiro.au/users/kli039/repos/ethereum-logging-framework/browse) - ક્વેરી લેંગ્વેજ, ક્વેરી પ્રોસેસર, અને સહિત ઇથેરિયમ એપ્લિકેશનો અને નેટવર્ક માટે અદ્યતન લોગીંગ ક્ષમતાઓ પ્રદાન કરે છે. લોગિંગ કોડ જનરેશન  
-
- 
+- [ઇથેરિયમ લgingગિંગ ફ્રેમવર્ક](https://bitbucket.csiro.au/users/kli039/repos/ethereum-logging-framework/browse) - ક્વેરી લેંગ્વેજ, ક્વેરી પ્રોસેસર, અને સહિત ઇથેરિયમ એપ્લિકેશનો અને નેટવર્ક માટે અદ્યતન લોગીંગ ક્ષમતાઓ પ્રદાન કરે છે. લોગિંગ કોડ જનરેશન
 
 #### ઇથેરિયમ ક્લાયન્ટ્સ
 
- 
+- [બેસુ](https://besu.hyperledger.org/en/latest/) - અપાચે 2.0 લાઇસેંસ હેઠળ વિકસિત અને જાવામાં લખાયેલ એક ઓપન સોર્સ ઇથેરિયમ ક્લાયંટ. આ પ્રોજેક્ટનું સંચાલન હાઇપરલેડર દ્વારા કરવામાં આવ્યું છે.
 
-- [બેસુ] (https://besu.hyperledger.org/en/latest/) - અપાચે 2.0 લાઇસેંસ હેઠળ વિકસિત અને જાવામાં લખાયેલ એક ઓપન સોર્સ ઇથેરિયમ ક્લાયંટ. આ પ્રોજેક્ટનું સંચાલન હાઇપરલેડર દ્વારા કરવામાં આવ્યું છે.  
+- [ગેથ](https://geth.ethereum.org/docs/) - ક્લાઈન્ટ જાઓ
 
-- [ગેથ] (https://geth.ethereum.org/docs/) - ક્લાઈન્ટ જાઓ  
+- [એરીગોન](https://github.com/ledgerwatch/erigon) - કાર્યક્ષમતા સીમા પર બનેલા ઇથેરિયમ ક્લાયંટનું મોટે ભાગે ગો અમલીકરણ
 
-- [એરીગોન] (https://github.com/ledgerwatch/erigon) - કાર્યક્ષમતા સીમા પર બનેલા ઇથેરિયમ ક્લાયંટનું મોટે ભાગે ગો અમલીકરણ  
+- [ઓપનએથેરિયમ](https://github.com/openethereum/openethereum) - રસ્ટ ક્લાયંટ, અગાઉ પેરિટી કહેવાતું. એરીગોનની તરફેણમાં અવમૂલ્યનનાં માર્ગ પર.
 
-- [ઓપનએથેરિયમ] (https://github.com/openethereum/openethereum) - રસ્ટ ક્લાયંટ, અગાઉ પેરિટી કહેવાતું. એરીગોનની તરફેણમાં અવમૂલ્યનનાં માર્ગ પર.  
+- [અલેથ](https://github.com/ethereum/aleth) - સી ++ ક્લાયંટ
 
-- [અલેથ] (https://github.com/ethereum/aleth) - સી ++ ક્લાયંટ  
+- [નેदरમિંડ](https://github.com/NethermindEth/nethermind) - .નેટ કોર ક્લાયંટ
 
-- [નેदरમિંડ] (https://github.com/NethermindEth/nethermind) - .નેટ કોર ક્લાયંટ  
+- [ઇન્ફુરા](https://infura.io/) - એથેરિયમ ક્લાયંટ ધોરણો-સુસંગત API પ્રદાન કરતી એક વ્યવસ્થાપિત સેવા
 
-- [ઇન્ફુરા] (https://infura.io/) - એથેરિયમ ક્લાયંટ ધોરણો-સુસંગત API પ્રદાન કરતી એક વ્યવસ્થાપિત સેવા  
+- [ટ્રિનિટી](https://trinity.ethereum.org/) - [py-evm](https://github.com/ethereum/py-evm) નો ઉપયોગ કરીને પાયથોન ક્લાયંટ
 
-- [ટ્રિનિટી] (https://trinity.ethereum.org/) - [py-evm] (https://github.com/ethereum/py-evm) નો ઉપયોગ કરીને પાયથોન ક્લાયંટ  
+- [ઇથેર્યુમ્સ](https://github.com/ethereumjs/ethereumjs-client) - જેએસ ક્લાયંટ [ethereumjs-vm] નો ઉપયોગ કરીને (https://github.com/ethereumjs/ethereumjs-vm)
 
-- [ઇથેર્યુમ્સ] (https://github.com/ethereumjs/ethereumjs-client) - જેએસ ક્લાયંટ [ethereumjs-vm] નો ઉપયોગ કરીને (https://github.com/ethereumjs/ethereumjs-vm)  
+- [શેઠ](https://github.com/dapphub/dapptools/tree/master/src/seth) - શેઠ એથેરિયમ ક્લાયંટ ટૂલ છે - જેમ કે "કમાન્ડ લાઇન માટે મેટામેસ્ક"
 
-- [શેઠ] (https://github.com/dapphub/dapptools/tree/master/src/seth) - શેઠ એથેરિયમ ક્લાયંટ ટૂલ છે - જેમ કે "કમાન્ડ લાઇન માટે મેટામેસ્ક"  
+- [મુસ્તેકલા](https://github.com/musteka-la/mustekala) - મેટામાસ્કનો ઇથેરિયમ લાઇટ ક્લાયંટ પ્રોજેક્ટ
 
-- [મુસ્તેકલા] (https://github.com/musteka-la/mustekala) - મેટામાસ્કનો ઇથેરિયમ લાઇટ ક્લાયંટ પ્રોજેક્ટ  
+- [એક્સ્ટિઅરિયમ](https://github.com/exthereum/ blockchain) - એલિક્સિર ક્લાયંટ
 
-- [એક્સ્ટિઅરિયમ] (https://github.com/exthereum/ blockchain) - એલિક્સિર ક્લાયંટ  
+- [EWF પેરિટી](https://github.com/energywebfoundation/energyweb-ui) - તોબલાબા પરીક્ષણ નેટવર્ક માટે એનર્જી વેબ ફાઉન્ડેશન ક્લાયંટ
 
-- [EWF પેરિટી] (https://github.com/energywebfoundation/energyweb-ui) - તોબલાબા પરીક્ષણ નેટવર્ક માટે એનર્જી વેબ ફાઉન્ડેશન ક્લાયંટ  
+- [કોરમ](https://github.com/jpmorganchase/quorum) - [જેપી મોર્ગન] દ્વારા ઇથેરિયમ સપોર્ટિંગ ડેટા ગોપનીયતાની મંજૂરી અમલીકરણ (https://jpmorgan.com/quorum)
 
-- [કોરમ] (https://github.com/jpmorganchase/quorum) - [જેપી મોર્ગન] દ્વારા ઇથેરિયમ સપોર્ટિંગ ડેટા ગોપનીયતાની મંજૂરી અમલીકરણ (https://jpmorgan.com/quorum)  
+- [મન](https://github.com/mana-ethereum/mana) - એલિસિરમાં ઇથેરિયમ પૂર્ણ નોડ અમલીકરણ.
 
-- [મન] (https://github.com/mana-ethereum/mana) - એલિસિરમાં ઇથેરિયમ પૂર્ણ નોડ અમલીકરણ.  
+- [ચેઇનસ્ટેક](https://chainstack.com/) - વહેંચાયેલ અને સમર્પિત ગેથ ગાંઠો પ્રદાન કરતી એક વ્યવસ્થાપિત સેવા
 
-- [ચેઇનસ્ટેક] (https://chainstack.com/) - વહેંચાયેલ અને સમર્પિત ગેથ ગાંઠો પ્રદાન કરતી એક વ્યવસ્થાપિત સેવા  
+- [ક્વિકનોડ](https://quiknode.io/) - API accessક્સેસ અને નોડ-એ-એ-સર્વિસ સાથે બ્લોકચેન વિકાસકર્તા મેઘ.
 
-- [ક્વિકનોડ] (https://quiknode.io/) - API accessક્સેસ અને નોડ-એ-એ-સર્વિસ સાથે બ્લોકચેન વિકાસકર્તા મેઘ.  
 
- 
-
- 
 
 #### સંગ્રહ
 
- 
+- [આઈપીએફએસ](https://ipfs.io/) - વિકેન્દ્રિત સ્ટોરેજ અને ફાઇલ સંદર્ભો
 
-- [આઈપીએફએસ] (https://ipfs.io/) - વિકેન્દ્રિત સ્ટોરેજ અને ફાઇલ સંદર્ભો  
+- [મહુતા](https://github.com/ConsenSys/Mahuta) - આઇપીએફએસ સ્ટોરેજ સર્વિસ ઉમેરવામાં શોધ ક્ષમતા, અગાઉ આઇપીએફએસ-સ્ટોર
 
-- [મહુતા] (https://github.com/ConsenSys/Mahuta) - આઇપીએફએસ સ્ટોરેજ સર્વિસ ઉમેરવામાં શોધ ક્ષમતા, અગાઉ આઇપીએફએસ-સ્ટોર  
+- [ઓર્બિટડીબી](https://github.com/orbitdb/orbit-db) - આઇપીએફએસની ટોચ પર વિકેન્દ્રિત ડેટાબેસ
 
-- [ઓર્બિટડીબી] (https://github.com/orbitdb/orbit-db) - આઇપીએફએસની ટોચ પર વિકેન્દ્રિત ડેટાબેસ  
+- [જેએસ આઈપીએફએસ એપીઆઇ](https://github.com/ipfs/js-ipfs-http-client) - જાવાસ્ક્રિપ્ટમાં લાગુ કરાયેલ આઇપીએફએસ HTTP API માટે ક્લાયન્ટ લાઇબ્રેરી
 
-- [જેએસ આઈપીએફએસ એપીઆઇ] (https://github.com/ipfs/js-ipfs-http-client) - જાવાસ્ક્રિપ્ટમાં લાગુ કરાયેલ આઇપીએફએસ HTTP API માટે ક્લાયન્ટ લાઇબ્રેરી  
+- [ટેમ્પરલ](https://github.com/RTradeLtd/Temporal) - IP ને અને અન્ય વિતરિત / વિકેન્દ્રિત સ્ટોરેજ પ્રોટોકોલોમાં API નો ઉપયોગ કરવો સરળ છે
 
-- [ટેમ્પરલ] (https://github.com/RTradeLtd/Temporal) - IP ને અને અન્ય વિતરિત / વિકેન્દ્રિત સ્ટોરેજ પ્રોટોકોલોમાં API નો ઉપયોગ કરવો સરળ છે  
+- [પિનટા](https://pinata.cloud) - આઈપીએફએસનો ઉપયોગ કરવાનો સૌથી સહેલો રસ્તો
 
-- [પિનટા] (https://pinata.cloud) - આઈપીએફએસનો ઉપયોગ કરવાનો સૌથી સહેલો રસ્તો  
+- [સ્વોર્મ](https://swarm-gateways.net/) - વિતરિત સ્ટોરેજ પ્લેટફોર્મ અને સામગ્રી વિતરણ સેવા, એથેરિયમ વેબ 3 સ્ટેકની મૂળ આધાર સ્તરની સેવા
 
-- [સ્વોર્મ] (https://swarm-gateways.net/) - વિતરિત સ્ટોરેજ પ્લેટફોર્મ અને સામગ્રી વિતરણ સેવા, એથેરિયમ વેબ 3 સ્ટેકની મૂળ આધાર સ્તરની સેવા  
+- [ઇન્ફુરા](https://infura.io/) - સંચાલિત આઇપીએફએસ API ગેટવે અને પિનિંગ સેવા
 
-- [ઇન્ફુરા] (https://infura.io/) - સંચાલિત આઇપીએફએસ API ગેટવે અને પિનિંગ સેવા  
+- [B બ Storageક્સ સ્ટોરેજ](https://docs.3box.io/api/st સંગ્રહ) - વપરાશકર્તા નિયંત્રિત, વિક્ષેપિત સંગ્રહ માટેનો એક એપીઆઈ. આઇપીએફએસ અને bitર્બિટબીબીની ટોચ પર બિલ્ટ.
 
-- [B બ Storageક્સ સ્ટોરેજ] (https://docs.3box.io/api/st સંગ્રહ) - વપરાશકર્તા નિયંત્રિત, વિક્ષેપિત સંગ્રહ માટેનો એક એપીઆઈ. આઇપીએફએસ અને bitર્બિટબીબીની ટોચ પર બિલ્ટ.  
-
-- [એલેફ.ઇમ] (https://aleph.im/) - એથેરિયમ અને આઇપીએફએસ સાથે સુસંગત પીઅર-ટૂ-પીઅર ક્લાઉડ પ્રોજેક્ટ (ડેટાબેસ, ફાઇલ સ્ટોરેજ, કમ્પ્યુટિંગ અને ડીઆઈડી) offફચેન પ્રોત્સાહિત.  
-
- 
+- [એલેફ.ઇમ](https://aleph.im/) - એથેરિયમ અને આઇપીએફએસ સાથે સુસંગત પીઅર-ટૂ-પીઅર ક્લાઉડ પ્રોજેક્ટ (ડેટાબેસ, ફાઇલ સ્ટોરેજ, કમ્પ્યુટિંગ અને ડીઆઈડી) offફચેન પ્રોત્સાહિત.
 
 #### બુટસ્ટ્રેપ / આઉટ-ઓફ-બ toolsક્સ ટૂલ્સ
 
- 
+- [ટ્રફલ બ boxesક્સ](https://trufflesuite.com/boxes) - ઇથેરિયમ ઇકોસિસ્ટમ માટેના પેકેજ્ડ ઘટકો
 
-- [ટ્રફલ બ boxesક્સ] (https://trufflesuite.com/boxes) - ઇથેરિયમ ઇકોસિસ્ટમ માટેના પેકેજ્ડ ઘટકો  
+- [ઇથ એપ્લિકેશન બનાવો](https://github.com/paulrberg/create-eth-app) - એક આદેશ સાથે ઇથેરિયમ સંચાલિત અગ્ર એપ્લિકેશનો બનાવો
 
-- [ઇથ એપ્લિકેશન બનાવો] (https://github.com/paulrberg/create-eth-app) - એક આદેશ સાથે ઇથેરિયમ સંચાલિત અગ્ર એપ્લિકેશનો બનાવો  
+- [બેસુ પ્રાઈવેટ નેટવર્ક](https://besu.hyperledger.org/en/stable/Tutorials/Quickstarts/Azure-Private-Network-Quickstart/) - ડોકર કન્ટેનરમાં બેસુ નોડ્સનું ખાનગી નેટવર્ક ચલાવો
 
-- [બેસુ પ્રાઈવેટ નેટવર્ક] (https://besu.hyperledger.org/en/stable/Tutorials/Quickstarts/Azure-Private-Network-Quickstart/) - ડોકર કન્ટેનરમાં બેસુ નોડ્સનું ખાનગી નેટવર્ક ચલાવો  
+- [ટેસ્ટચેઇન્સ](https://github.com/Nethereum/TestChains) - ઝડપી રૂપરેખા માટે પૂર્વ રૂપરેખાંકિત. NET devchains (PoA)
 
-- [ટેસ્ટચેઇન્સ] (https://github.com/Nethereum/TestChains) - ઝડપી રૂપરેખા માટે પૂર્વ રૂપરેખાંકિત. NET devchains (PoA)  
+- [બ્લેઝર / બ્લોકચેન એક્સપ્લોરર) (https://github.com/Nethereum/NethereumBlazor) - વાયરસ બ્લોકચેન સંશોધક (કાર્યાત્મક નમૂના)
 
-- [બ્લેઝર / બ્લોકચેન એક્સપ્લોરર) (https://github.com/Nethereum/NethereumBlazor) - વાયરસ બ્લોકચેન સંશોધક (કાર્યાત્મક નમૂના)  
+- [સ્થાનિક રાઇડન](https://github.com/ConsenSys/Local-Raiden) - ડેમો અને પરીક્ષણ હેતુ માટે ડોકર કન્ટેનરમાં સ્થાનિક રેઇડન નેટવર્ક ચલાવો
 
-- [સ્થાનિક રાઇડન] (https://github.com/ConsenSys/Local-Raiden) - ડેમો અને પરીક્ષણ હેતુ માટે ડોકર કન્ટેનરમાં સ્થાનિક રેઇડન નેટવર્ક ચલાવો  
+- [ખાનગી નેટવર્ક્સ જમાવટ સ્ક્રિપ્ટો](https://github.com/ConsenSys/private-networks-dep રોજગાર- સ્ક્રિપ્ટ્સ) - ખાનગી PoA નેટવર્ક્સ માટે આઉટ-ઓફ-બ depક્સ જમાવટ સ્ક્રિપ્ટ્સ
 
-- [ખાનગી નેટવર્ક્સ જમાવટ સ્ક્રિપ્ટો] (https://github.com/ConsenSys/private-networks-dep રોજગાર- સ્ક્રિપ્ટ્સ) - ખાનગી PoA નેટવર્ક્સ માટે આઉટ-ઓફ-બ depક્સ જમાવટ સ્ક્રિપ્ટ્સ  
+- [પેરિટી ડેમો-પીઓએ ટ્યુટોરિયલ](https://wiki.parity.io/Demo-PoA-tutorial.html) - પેરિટી ઓથોરિટી રાઉન્ડ સર્વસંમતિ સાથે 2 ગાંઠો સાથે પીઓએ ટેસ્ટ સાંકળ બનાવવા માટે પગલું દ્વારા પગલું ટ્યુટોરિયલ
 
-- [પેરિટી ડેમો-પીઓએ ટ્યુટોરિયલ] (https://wiki.parity.io/Demo-PoA-tutorial.html) - પેરિટી ઓથોરિટી રાઉન્ડ સર્વસંમતિ સાથે 2 ગાંઠો સાથે પીઓએ ટેસ્ટ સાંકળ બનાવવા માટે પગલું દ્વારા પગલું ટ્યુટોરિયલ  
+- [લોકલ ઇથેરિયમ નેટવર્ક](https://github.com/ConsenSys/local_ethereum_network) - ખાનગી PoW નેટવર્ક માટે આઉટ-ઓફ-બ depક્સ જમાવટ સ્ક્રિપ્ટ્સ
 
-- [લોકલ ઇથેરિયમ નેટવર્ક] (https://github.com/ConsenSys/local_ethereum_network) - ખાનગી PoW નેટવર્ક માટે આઉટ-ઓફ-બ depક્સ જમાવટ સ્ક્રિપ્ટ્સ  
+- [કાલિડો](https://kaleido.io/) - કન્સોર્ટિયમ બ્લોકચેન નેટવર્ક સ્પિન કરવા માટે કાલિડોનો ઉપયોગ કરો. પીઓસી અને પરીક્ષણ માટે સરસ
 
-- [કાલિડો] (https://kaleido.io/) - કન્સોર્ટિયમ બ્લોકચેન નેટવર્ક સ્પિન કરવા માટે કાલિડોનો ઉપયોગ કરો. પીઓસી અને પરીક્ષણ માટે સરસ  
+- [ચેશાયર](https://github.com/endless-nameless-inc/cheshire) - ક્રિપ્ટોકિટ્સ એપીઆઇ અને સ્માર્ટ કરારનું સ્થાનિક સેન્ડબોક્સ અમલીકરણ, ટ્રફલ બ asક્સ તરીકે ઉપલબ્ધ
 
-- [ચેશાયર] (https://github.com/endless-nameless-inc/cheshire) - ક્રિપ્ટોકિટ્સ એપીઆઇ અને સ્માર્ટ કરારનું સ્થાનિક સેન્ડબોક્સ અમલીકરણ, ટ્રફલ બ asક્સ તરીકે ઉપલબ્ધ  
+- [એરેગોનસીએલઆઈ) (https://github.com/aragon/aragon-cli) - એરેગોનસીએલનો ઉપયોગ એરેગોન એપ્લિકેશનો અને સંગઠનો બનાવવા અને વિકસાવવા માટે થાય છે.
 
-- [એરેગોનસીએલઆઈ) (https://github.com/aragon/aragon-cli) - એરેગોનસીએલનો ઉપયોગ એરેગોન એપ્લિકેશનો અને સંગઠનો બનાવવા અને વિકસાવવા માટે થાય છે.  
+- [કોલોનીજેએસ](https://github.com/JoinColony/colonyJS) - જાવાસ્ક્રિપ્ટ ક્લાયંટ કે કોલોની નેટવર્ક સ્માર્ટ કરાર સાથે ક્રિયાપ્રતિક્રિયા માટે એક API પ્રદાન કરે છે.
 
-- [કોલોનીજેએસ] (https://github.com/JoinColony/colonyJS) - જાવાસ્ક્રિપ્ટ ક્લાયંટ કે કોલોની નેટવર્ક સ્માર્ટ કરાર સાથે ક્રિયાપ્રતિક્રિયા માટે એક API પ્રદાન કરે છે.  
+- [આર્કજેએસ](https://github.com/daostack/arc.js) - લાઇબ્રેરી જે DAOstack આર્ક ઇથેરિયમ સ્માર્ટ કરારો પર જાવાસ્ક્રિપ્ટ એપ્લિકેશનની facilક્સેસને સગવડ આપે છે.
 
-- [આર્કજેએસ] (https://github.com/daostack/arc.js) - લાઇબ્રેરી જે DAOstack આર્ક ઇથેરિયમ સ્માર્ટ કરારો પર જાવાસ્ક્રિપ્ટ એપ્લિકેશનની facilક્સેસને સગવડ આપે છે.  
+- [આર્કાને કનેક્ટ](https://docs.arkane.network/pages/connect-js.html) - જાવાસ્ક્રિપ્ટ ક્લાયંટ જે વપરાશકર્તા-મૈત્રીપૂર્ણ ડેપ્સ બનાવવા માટેનું વletલેટ પ્રદાતા આર્કાને નેટવર્ક સાથે સંપર્ક કરવા માટે એક API પ્રદાન કરે છે.
 
-- [આર્કાને કનેક્ટ] (https://docs.arkane.network/pages/connect-js.html) - જાવાસ્ક્રિપ્ટ ક્લાયંટ જે વપરાશકર્તા-મૈત્રીપૂર્ણ ડેપ્સ બનાવવા માટેનું વletલેટ પ્રદાતા આર્કાને નેટવર્ક સાથે સંપર્ક કરવા માટે એક API પ્રદાન કરે છે.  
+- [ઓનબોર્ડ.જેએસ](https:// blocknative.com/onboard) - બ્લોકનેટીવ boardનબોર્ડ એ તમારા પ્રોજેક્ટમાં મલ્ટિ-વletલેટ સપોર્ટ ઉમેરવાની ઝડપી અને સરળ રીત છે. 20 થી વધુ અનન્ય હાર્ડવેર અને સ softwareફ્ટવેર વletsલેટ્સ માટે બિલ્ટ-ઇન મોડ્યુલ્સ સાથે, boardનબોર્ડ તમને સમય અને માથાનો દુખાવો બચાવે છે.
 
-- [ઓનબોર્ડ.જેએસ] (https:// blocknative.com/onboard) - બ્લોકનેટીવ boardનબોર્ડ એ તમારા પ્રોજેક્ટમાં મલ્ટિ-વletલેટ સપોર્ટ ઉમેરવાની ઝડપી અને સરળ રીત છે. 20 થી વધુ અનન્ય હાર્ડવેર અને સ softwareફ્ટવેર વletsલેટ્સ માટે બિલ્ટ-ઇન મોડ્યુલ્સ સાથે, boardનબોર્ડ તમને સમય અને માથાનો દુખાવો બચાવે છે.  
-
-- [વેબ--રિએક્ટ] (https://github.com/NoahZinsmeister/web3-react) - સિંગલ-પેજ ઇથેરિયમ ડી એપ્સ બનાવવા માટેનો ફ્રેમવર્ક  
-
- 
+- [વેબ--રિએક્ટ](https://github.com/NoahZinsmeister/web3-react) - સિંગલ-પેજ ઇથેરિયમ ડી એપ્સ બનાવવા માટેનો ફ્રેમવર્ક
 
 #### ઇથેરિયમ એબીઆઇ (એપ્લિકેશન બાઈનરી ઇંટરફેસ) ટૂલ્સ
 
- 
+- [એબીઆઈ ડીકોડર](https://github.com/ConsenSys/abi-decoder) - ઇથેરિયમ ટ્રાન્ઝેક્શનથી ડેટા પરિમાણો અને ઇવેન્ટ્સને ડીકોડ કરવા માટેની લાઇબ્રેરી
 
-- [એબીઆઈ ડીકોડર] (https://github.com/ConsenSys/abi-decoder) - ઇથેરિયમ ટ્રાન્ઝેક્શનથી ડેટા પરિમાણો અને ઇવેન્ટ્સને ડીકોડ કરવા માટેની લાઇબ્રેરી  
+- [એબીઆઇ-જન]](https://github.com/0xProject/0x-monorepo/tree/de વિકાસment/packages/abi-gen) - કરાર એબીઆઇના ટાઇપસ્ક્રિપ્ટ કરાર રેપર્સ બનાવો.
 
-- [એબીઆઇ-જન]] (https://github.com/0xProject/0x-monorepo/tree/de વિકાસment/packages/abi-gen) - કરાર એબીઆઇના ટાઇપસ્ક્રિપ્ટ કરાર રેપર્સ બનાવો.  
+- [ઇથેરિયમ એબીઆઈ યુઆઈ](https://github.com/hiddentao/ethereum-abi-ui) - ઇથેરિયમ કરાર એબીઆઈ તરફથી UI ફોર્મ ફીલ્ડ વ્યાખ્યાઓ અને સંબંધિત વેલિડેટર્સને સ્વત--જનરેટ કરે છે.
 
-- [ઇથેરિયમ એબીઆઈ યુઆઈ] (https://github.com/hiddentao/ethereum-abi-ui) - ઇથેરિયમ કરાર એબીઆઈ તરફથી UI ફોર્મ ફીલ્ડ વ્યાખ્યાઓ અને સંબંધિત વેલિડેટર્સને સ્વત--જનરેટ કરે છે.  
+- [હેડલાંગ](https://github.com/esaulpaugh/headlong/) - જાવામાં ટાઇપ-સેફ કોન્ટ્રાક્ટ એબીઆઈ અને રિકરિવ લંબાઈ પ્રીફિક્સ લાઇબ્રેરી
 
-- [હેડલાંગ] (https://github.com/esaulpaugh/headlong/) - જાવામાં ટાઇપ-સેફ કોન્ટ્રાક્ટ એબીઆઈ અને રિકરિવ લંબાઈ પ્રીફિક્સ લાઇબ્રેરી  
+- [ઇઝિડેપ્પર](https://www.easydapper.com) - ટ્રફલ આર્ટિફેક્ટ્સમાંથી ડppપ્સ બનાવો, જાહેર / ખાનગી નેટવર્ક પર કરાર ગોઠવો, કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવા માટે લાઇવ કસ્ટમાઇઝ સાર્વજનિક પૃષ્ઠ પ્રદાન કરે છે.
 
-- [ઇઝિડેપ્પર] (https://www.easydapper.com) - ટ્રફલ આર્ટિફેક્ટ્સમાંથી ડppપ્સ બનાવો, જાહેર / ખાનગી નેટવર્ક પર કરાર ગોઠવો, કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવા માટે લાઇવ કસ્ટમાઇઝ સાર્વજનિક પૃષ્ઠ પ્રદાન કરે છે.  
+- [વન ક્લીક ડીએપ્પી](https://oneclickdapp.com) - એબીઆઇનો ઉપયોગ કરીને અનન્ય URL પર તુરંત જ એક ડીપીપી બનાવો.
 
-- [વન ક્લીક ડીએપ્પી] (https://oneclickdapp.com) - એબીઆઇનો ઉપયોગ કરીને અનન્ય URL પર તુરંત જ એક ડીપીપી બનાવો.  
+- [ટ્રફલ પિગ](https://npmjs.com/package/trufflepig) - એક વિકાસ સાધન જે સ્થાનિક વિકાસ દરમિયાન ઉપયોગ માટે, ટ્રફલ જનરેટ કરાર ફાઇલો શોધવા અને વાંચવા માટે એક સરળ HTTP API પ્રદાન કરે છે. એ.બી.આઇ. ને HTTP ઉપર નવા કરારની સેવા આપે છે.
 
-- [ટ્રફલ પિગ] (https://npmjs.com/package/trufflepig) - એક વિકાસ સાધન જે સ્થાનિક વિકાસ દરમિયાન ઉપયોગ માટે, ટ્રફલ જનરેટ કરાર ફાઇલો શોધવા અને વાંચવા માટે એક સરળ HTTP API પ્રદાન કરે છે. એ.બી.આઇ. ને HTTP ઉપર નવા કરારની સેવા આપે છે.  
+- [ઇથેરિયમ કરાર સેવા](https://github.com/mesg-foundation/service-ethereum-contract) - તેના સરનામાં અને એબીઆઈના આધારે કોઈપણ ઇથેરિયમ કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવા માટે એક એમઇએસજી સેવા.
 
-- [ઇથેરિયમ કરાર સેવા] (https://github.com/mesg-foundation/service-ethereum-contract) - તેના સરનામાં અને એબીઆઈના આધારે કોઈપણ ઇથેરિયમ કરાર સાથે ક્રિયાપ્રતિક્રિયા કરવા માટે એક એમઇએસજી સેવા.  
+- [નેથેરિયમ-કોડજનેરેટર](https://github.com/StefH/Nethereum-CodeGenerator) - વેબ આધારિત જનરેટર જે સોલિડિટી સ્માર્ટ કોન્ટ્રાક્ટ્સ પર આધારિત નેથેરિયમ આધારિત સી # ઇંટરફેસ અને સેવા બનાવે છે.
 
-- [નેથેરિયમ-કોડજનેરેટર] (https://github.com/StefH/Nethereum-CodeGenerator) - વેબ આધારિત જનરેટર જે સોલિડિટી સ્માર્ટ કોન્ટ્રાક્ટ્સ પર આધારિત નેથેરિયમ આધારિત સી # ઇંટરફેસ અને સેવા બનાવે છે.  
 
- 
-
- 
 
 # પરીક્ષણ સાધનો
 
- 
+- [ટ્રુફલ ટીમ્સ](https://trufflesuite.com/teams) - ટ્રુફલ પ્રોજેક્ટ્સ માટે ઝીરો-કન્ફિગન સતત એકીકરણ
 
-- [ટ્રુફલ ટીમ્સ] (https://trufflesuite.com/teams) - ટ્રુફલ પ્રોજેક્ટ્સ માટે ઝીરો-કન્ફિગન સતત એકીકરણ  
+- [સોલિડિટી કોડ કવરેજ](https://github.com/0xProject/0x-monorepo/tree/de વિકાસment/packages/sol-coverage) - સોલિડિટી કોડ કવરેજ ટૂલ
 
-- [સોલિડિટી કોડ કવરેજ] (https://github.com/0xProject/0x-monorepo/tree/de વિકાસment/packages/sol-coverage) - સોલિડિટી કોડ કવરેજ ટૂલ  
+- [સોલિડિટી કવરેજ](https://github.com/sc-forks/solity-coverage) - સોલિડિટી સ્માર્ટ-કરાર માટે વૈકલ્પિક કોડ કવરેજ
 
-- [સોલિડિટી કવરેજ] (https://github.com/sc-forks/solity-coverage) - સોલિડિટી સ્માર્ટ-કરાર માટે વૈકલ્પિક કોડ કવરેજ  
+- [સોલિડિટી ફંક્શન પ્રોફાઇલર](https://github.com/EricR/sol-function-profiler) - સોલિડિટી કોન્ટ્રેક્ટ ફંક્શન પ્રોફાઇલર
 
-- [સોલિડિટી ફંક્શન પ્રોફાઇલર] (https://github.com/EricR/sol-function-profiler) - સોલિડિટી કોન્ટ્રેક્ટ ફંક્શન પ્રોફાઇલર  
+- [સોલ-પ્રોફાઇલર](https://github.com/Aniket-Engg/sol-profiler) - વૈકલ્પિક અને અપડેટ સોલિડિટી સ્માર્ટ કરાર પ્રોફાઇલર
 
-- [સોલ-પ્રોફાઇલર] (https://github.com/Aniket-Engg/sol-profiler) - વૈકલ્પિક અને અપડેટ સોલિડિટી સ્માર્ટ કરાર પ્રોફાઇલર  
+- [એસ્પ્રેસો](https://github.com/hillstreetlabs/espresso) - ઝડપી, સમાંતર, ગરમ-ફરીથી લોડિંગ ઘનતા પરીક્ષણ ફ્રેમવર્ક
 
-- [એસ્પ્રેસો] (https://github.com/hillstreetlabs/espresso) - ઝડપી, સમાંતર, ગરમ-ફરીથી લોડિંગ ઘનતા પરીક્ષણ ફ્રેમવર્ક  
+- [ઇથ ટેસ્ટર](https://github.com/ethereum/eth-tester) - ઇથેરિયમ એપ્લિકેશન્સના પરીક્ષણ માટે ટૂલ સ્યુટ
 
-- [ઇથ ટેસ્ટર] (https://github.com/ethereum/eth-tester) - ઇથેરિયમ એપ્લિકેશન્સના પરીક્ષણ માટે ટૂલ સ્યુટ  
+- [ક્લીક્વેબાઇટ](https://github.com/foam/cliquebait) - એકીકરણ અને સ્માર્ટ કોન્ટ્રાક્ટ એપ્લિકેશન્સના પરીક્ષણને ડોકરના દાખલાઓથી સાદા કરે છે જે વાસ્તવિક બ્લોકચેન નેટવર્કને મળતું આવે છે.
 
-- [ક્લીક્વેબાઇટ] (https://github.com/foam/cliquebait) - એકીકરણ અને સ્માર્ટ કોન્ટ્રાક્ટ એપ્લિકેશન્સના પરીક્ષણને ડોકરના દાખલાઓથી સાદા કરે છે જે વાસ્તવિક બ્લોકચેન નેટવર્કને મળતું આવે છે.  
+- [હેવમ](https://github.com/dapphub/dapptools/tree/master/src/hevm) - હેવમ પ્રોજેક્ટ એ ઇથેરિયમ વર્ચ્યુઅલ મશીન (ઇવીએમ) નો અમલીકરણ છે જે ખાસ કરીને યુનિટ પરીક્ષણ અને ડિબગીંગ સ્માર્ટ કરાર માટે છે
 
-- [હેવમ] (https://github.com/dapphub/dapptools/tree/master/src/hevm) - હેવમ પ્રોજેક્ટ એ ઇથેરિયમ વર્ચ્યુઅલ મશીન (ઇવીએમ) નો અમલીકરણ છે જે ખાસ કરીને યુનિટ પરીક્ષણ અને ડિબગીંગ સ્માર્ટ કરાર માટે છે  
+- [ઇથેરિયમ ગ્રાફ ડીબગર](https://github.com/fergarrui/ethereum-راف-debugger) - સોલિડિટી ગ્રાફિકલ ડિબગર
 
-- [ઇથેરિયમ ગ્રાફ ડીબગર] (https://github.com/fergarrui/ethereum-راف-debugger) - સોલિડિટી ગ્રાફિકલ ડિબગર  
+- [ટેન્ડરલી સીએલઆઈ](https://github.com/Tenderly/tenderly-cli) - માનવ વાંચવા યોગ્ય સ્ટેક ટ્રેસ સાથે તમારા વિકાસને વેગ આપો
 
-- [ટેન્ડરલી સીએલઆઈ] (https://github.com/Tenderly/tenderly-cli) - માનવ વાંચવા યોગ્ય સ્ટેક ટ્રેસ સાથે તમારા વિકાસને વેગ આપો  
+- [સોલહિન્ટ](https://github.com/protofire/solhint) - સોલિડિટી લાઇનટર જે સ્માર્ટ કરાર માન્યતા માટે સુરક્ષા, શૈલી માર્ગદર્શિકા અને શ્રેષ્ઠ અભ્યાસના નિયમો પ્રદાન કરે છે.
 
-- [સોલહિન્ટ] (https://github.com/protofire/solhint) - સોલિડિટી લાઇનટર જે સ્માર્ટ કરાર માન્યતા માટે સુરક્ષા, શૈલી માર્ગદર્શિકા અને શ્રેષ્ઠ અભ્યાસના નિયમો પ્રદાન કરે છે.  
+- [એથલિન્ટ](https://github.com/duaraghav8/Ethlint) - નક્કરતામાં શૈલી અને સુરક્ષાના મુદ્દાઓને ઓળખવા અને તેને ઠીક કરવા માટેનું લિટર, અગાઉ સોલિયમ
 
-- [એથલિન્ટ] (https://github.com/duaraghav8/Ethlint) - નક્કરતામાં શૈલી અને સુરક્ષાના મુદ્દાઓને ઓળખવા અને તેને ઠીક કરવા માટેનું લિટર, અગાઉ સોલિયમ  
+- [ડીકોડ](https://github.com/hacker-DOM/decode) - npm પેકેજ કે જે tx ને સ્થાનિક પરીક્ષણ નોડ પર સબમિટ કરેલું વિશ્લેષણ કરે છે જેથી તેમને વધુ વાંચવા યોગ્ય અને સમજવા માટે સરળ બનાવવામાં આવે.
 
-- [ડીકોડ] (https://github.com/hacker-DOM/decode) - npm પેકેજ કે જે tx ને સ્થાનિક પરીક્ષણ નોડ પર સબમિટ કરેલું વિશ્લેષણ કરે છે જેથી તેમને વધુ વાંચવા યોગ્ય અને સમજવા માટે સરળ બનાવવામાં આવે.  
+- [ટ્રફલ-નિવેદનો](https://github.com/rkalis/truffle-assertions) - ટ્રફલ સાથે સોલિડિટી સ્માર્ટ કોન્ટ્રાક્ટ્સના પરીક્ષણમાં ઉપયોગમાં લેવાતા વધારાના દાવા અને ઉપયોગિતાઓ સાથેનો એક એનપીએમ પેકેજ. સૌથી અગત્યનું, તે ચોક્કસ ઘટનાઓ બહાર કા addsવામાં આવી છે કે નહીં તે નિશ્ચિત કરવાની ક્ષમતા ઉમેરશે.
 
-- [ટ્રફલ-નિવેદનો] (https://github.com/rkalis/truffle-assertions) - ટ્રફલ સાથે સોલિડિટી સ્માર્ટ કોન્ટ્રાક્ટ્સના પરીક્ષણમાં ઉપયોગમાં લેવાતા વધારાના દાવા અને ઉપયોગિતાઓ સાથેનો એક એનપીએમ પેકેજ. સૌથી અગત્યનું, તે ચોક્કસ ઘટનાઓ બહાર કા addsવામાં આવી છે કે નહીં તે નિશ્ચિત કરવાની ક્ષમતા ઉમેરશે.  
+- [પ્સોલ](https://github.com/Lamarkaz/psol) - મૂછો.જેએસ-સ્ટાઇલ સિન્ટેક્સ, મેક્રોઝ, શરતી સંકલન અને સ્વચાલિત રિમોટ અવલંબન સમાવેશ સાથે સોલિડિટી લેક્સિકલ પ્રિપ્રોસેસર.
 
-- [પ્સોલ] (https://github.com/Lamarkaz/psol) - મૂછો.જેએસ-સ્ટાઇલ સિન્ટેક્સ, મેક્રોઝ, શરતી સંકલન અને સ્વચાલિત રિમોટ અવલંબન સમાવેશ સાથે સોલિડિટી લેક્સિકલ પ્રિપ્રોસેસર.  
+- [સોલપ](https://github.com/merklejerk/solpp) - સોલિડિટી પ્રિપ્રોસેસર અને વ્યાપક નિર્દેશન અને અભિવ્યક્તિની ભાષા, ઉચ્ચ ચોકસાઇવાળા ગણિત અને ઘણા ઉપયોગી સહાયક કાર્યો સાથે ફ્લેટનર.
 
-- [સોલપ] (https://github.com/merklejerk/solpp) - સોલિડિટી પ્રિપ્રોસેસર અને વ્યાપક નિર્દેશન અને અભિવ્યક્તિની ભાષા, ઉચ્ચ ચોકસાઇવાળા ગણિત અને ઘણા ઉપયોગી સહાયક કાર્યો સાથે ફ્લેટનર.  
+- [ડીકોડ અને પ્રકાશિત કરો) (https://flightwallet.github.io/decode-eth-tx/) - કાચા ઇથેરિયમ ટીએક્સને ડિકોડ અને પ્રકાશિત કરો. Https://live. blockcyumber.com/btc-testnet/decodetx/ જેવું જ
 
-- [ડીકોડ અને પ્રકાશિત કરો) (https://flightwallet.github.io/decode-eth-tx/) - કાચા ઇથેરિયમ ટીએક્સને ડિકોડ અને પ્રકાશિત કરો. Https://live. blockcyumber.com/btc-testnet/decodetx/ જેવું જ  
+- [ડોપેલગäન્ગર](https://getdoppelganger.io/) - એકમ પરીક્ષણ દરમિયાન સ્માર્ટ કરારની અવલંબનની મશ્કરી કરવા માટેની લાઇબ્રેરી.
 
-- [ડોપેલગäન્ગર] (https://getdoppelganger.io/) - એકમ પરીક્ષણ દરમિયાન સ્માર્ટ કરારની અવલંબનની મશ્કરી કરવા માટેની લાઇબ્રેરી.  
+- [રોકેથ](https://github.com/wighawag/rocketh) - ઇથેરિયમ સ્માર્ટ કરારને ચકાસવા માટેનું એક સરળ લિબ્સ જે તમે પસંદ કરેલા વેબ 3 લિબ અને પરીક્ષણ દોડવીરનો ઉપયોગ કરવાની મંજૂરી આપે છે.
 
-- [રોકેથ] (https://github.com/wighawag/rocketh) - ઇથેરિયમ સ્માર્ટ કરારને ચકાસવા માટેનું એક સરળ લિબ્સ જે તમે પસંદ કરેલા વેબ 3 લિબ અને પરીક્ષણ દોડવીરનો ઉપયોગ કરવાની મંજૂરી આપે છે.  
+- [પાઇસ્ટેસ્ટ-કોબ્રા](https://github.com/cobraframework/pytest-cobra) - ઇથેરિયમ બ્લોકચેન માટે સ્માર્ટ કરારનું પરીક્ષણ કરવા માટે પાઈટેસ્ટ પ્લગઇન.
 
-- [પાઇસ્ટેસ્ટ-કોબ્રા] (https://github.com/cobraframework/pytest-cobra) - ઇથેરિયમ બ્લોકચેન માટે સ્માર્ટ કરારનું પરીક્ષણ કરવા માટે પાઈટેસ્ટ પ્લગઇન.  
 
- 
-
- 
 
 #### વ્યવહાર વિઝ્યુલાઇઝેશન, સ્કોરિંગ અને ટ્રેકિંગ:
 
- 
+- [સી-શિકારી](http://c-hound.ai)
 
-- [સી-શિકારી] (http://c-hound.ai)  
+- [બ્લોકપથ](http:// blockpath.com)
 
-- [બ્લોકપથ] (http:// blockpath.com)  
+- [માલટેગો](http://maltego.com)
 
-- [માલટેગો] (http://maltego.com)  
+- [ગ્રાફસેન્સ](http://graphsense.info)
 
-- [ગ્રાફસેન્સ] (http://graphsense.info)  
+- [AML Bot](https://amlbot.com)
 
-- [AML Bot] (https://amlbot.com)  
+- [બેંક ચકાસેલું](https://bitrankverified.com/home)
 
-- [બેંક ચકાસેલું] (https://bitrankverified.com/home)  
+- [ઓર્બિટ](https://github.com/s0md3v/ ઓર્બિટ)
 
-- [ઓર્બિટ] (https://github.com/s0md3v/ ઓર્બિટ)  
+- [એરોનેક્સ](https://github.com/Cryptonomic/Arronax)
 
-- [એરોનેક્સ] (https://github.com/Cryptonomic/Arronax)  
+- [બ્લocksક્સકાઉટ](https://github.com/blockscout/blockscout)
 
-- [બ્લocksક્સકાઉટ] (https://github.com/blockscout/blockscout)  
+- [બીટીસી પાર્સર](https://btcparser.com)
 
-- [બીટીસી પાર્સર] (https://btcparser.com)  
+- [Txstreet](https://txstreet.com/v/eth)
 
-- [Txstreet] (https://txstreet.com/v/eth)  
+- [નેન્સેન](https://www.nansen.ai)
 
-- [નેન્સેન] (https://www.nansen.ai)  
+- [બ્લxyક્સી](https://bloxy.info)
 
-- [બ્લxyક્સી] (https://bloxy.info)  
+- [સોલના એક્સપ્લોરર (https://solscan.io)
 
-- [સોલના એક્સપ્લોરર (https://solscan.io)  
+- [અંડાશય](https://www.elliptic.co)
 
-- [અંડાશય] (https://www.elliptic.co)  
+- [એએનચેન એઆઈ](https://www.anchain.ai)
 
-- [એએનચેન એઆઈ] (https://www.anchain.ai)  
+- [સાઇફર ટ્રેસ](https://ciphertrace.com)
 
-- [સાઇફર ટ્રેસ] (https://ciphertrace.com)  
+- [ક્રિસ્ટલ બ્લોકચેન](https://crystal blockchain.com/products)
 
-- [ક્રિસ્ટલ બ્લોકચેન] (https://crystal blockchain.com/products)  
+- [અપ્સલા સિક્યુરિટી](https://uppsalasecurity.com)
 
-- [અપ્સલા સિક્યુરિટી] (https://uppsalasecurity.com)  
+- [સિક્કાફર્મ](https://www.coinfirm.com)
 
-- [સિક્કાફર્મ] (https://www.coinfirm.com)  
+- [સોલિડસ લેબ્સ](https://www.soliduslabs.com)
 
-- [સોલિડસ લેબ્સ] (https://www.soliduslabs.com)  
+- [ટીઆરએમ લેબ્સ](https://trmlabs.com)
 
-- [ટીઆરએમ લેબ્સ] (https://trmlabs.com)  
+- [હ Halલોર્ન ફોરેન્સિક](https://halborn.com)
 
-- [હ Halલોર્ન ફોરેન્સિક] (https://halborn.com)  
 
- 
-
- 
 
 ## સપોર્ટ પ્રોજેક્ટ:
 
- 
 
- 
 
-આધાર મારા માટે ** ખૂબ જ ** મહત્વપૂર્ણ છે, તેની સાથે હું કામ પર ઓછો સમય વિતાવી શકું છું અને મને જે ગમે છે તે કરી શકું છું - ડેફાઇ અને ક્રિપ્ટો વપરાશકર્તાઓને શિક્ષિત કરું છું: સ્પાર્કલિંગ_હાર્ટ:
-
- 
+આધાર મારા માટે**ખૂબ જ**મહત્વપૂર્ણ છે, તેની સાથે હું કામ પર ઓછો સમય વિતાવી શકું છું અને મને જે ગમે છે તે કરી શકું છું - ડેફાઇ અને ક્રિપ્ટો વપરાશકર્તાઓને શિક્ષિત કરું છું: સ્પાર્કલિંગ_હાર્ટ:
 
 જો તમે મારા કામને ટેકો આપવા માંગતા હો, તો તમે મને સરનામાં પર દાન મોકલી શકો છો:
-** 0xB25C5E8fA1E53eEb9bE3421C59F6A66B786ED77A ** - ERC20 અને ETH
-** 32kToCep8CiSS1mLAYE763xBbZaeoHtFgi ** - બીટીસી
+**0xB25C5E8fA1E53eEb9bE3421C59F6A66B786ED77A**- ERC20 અને ETH
+**32kToCep8CiSS1mLAYE763xBbZaeoHtFgi**- બીટીસી
 ##
 (👍 ͡❛ ͜ʖ ͡❛) 👍
 
- 
+
 [![Support Project](https://img.shields.io/badge/Support-Project-critical)](https://github.com/OffcierCia/DeFi-Developer-Road-Map#support-project) [![Research Base](https://img.shields.io/badge/Research-Base-lightgrey )](https://github.com/OffcierCia/ultimate-defi-research-base) [![Supported by LEGO](https://img.shields.io/badge/Supported%20by-LEGO-%2300A3FF)](https://www.notion.so/LEGO-Lido-Ecosystem-Grants-Organisation-d7f0bf0182d44348b6173639d2e8363d) [![Mail](https://img.shields.io/badge/Mail-offcierciapr%40protonmail.com-brightgreen)](mailto:offcierciapr@protonmail.com)

--- a/translations/README_ko.md
+++ b/translations/README_ko.md
@@ -15,7 +15,7 @@
 
 ## 로드맵
 
-![Roadmap](./DeFiDevRroadMap_-Page-1.svg)
+![Roadmap](../DeFiDevRroadMap_-4-Page-1.svg)
 
 # Navigation
 


### PR DESCRIPTION
Both of the translated READMEs(`README_ko.md` and `README_guj.md`) contains invalid markdown syntax and outdated images paths. This PR updates it.