### PR TITLE
Add new site to Web2 cybersecurity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@
 - [Pentesterlab](https://pentesterlab.com/) - Hands-on labs covering different bu classes from basic to advanced.
 - [Portswigger labs](https://portswigger.net/web-security/all-labs) - Set of web application secrity labs with attached community solutions
 - [Vulnhub](https://www.vulnhub.com/) - Users upload "challenge boxes" that often attempt to gain root access by exploiting known vulnerabilities.
+- [LabEx Cybersecurity Skill Tree](https://labex.io/skilltrees/cybersecurity) - Hands-on labs for cyber security, covering tools like Nmap, Wireshark, Kali, and more.
 
 ##### Web3 cybersecurity
 


### PR DESCRIPTION
Add LabEx to Web2 cybersecurity section

I work at LabEx, a unique learning platform that has delivered thousands of hands-on labs over the past 7 years. Our Cybersecurity Skill Tree currently offers 34 foundational skills and 80 hands-on labs, making it perfect for beginners to learn cybersecurity step by step. 

This repo is a great resource. Please let me know if any changes are needed.