### PR TITLE
add NOWNodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@
 - [Ethereum on Google Cloud](https://console.cloud.google.com/marketplace/details/click-to-deploy-images/ethereum?filter=category:developer-tools) - Build Ethereum network based on Proof of Work
 - [Infura](https://infura.io/) - Ethereum API access to Ethereum networks (Mainnet, Ropsten, Rinkeby, Goerli, Kovan)
 - [CloudFlare Distributed Web Gateway](https://cloudflare.com/distributed-web-gateway/) - Provides access to the Ethereum network through the Cloudflare instead of running your own node
+- [NOWNodes](https://nownodes.io/) - NOWNodes provide a full access to Ethereum testnets and access to more than 110 blockchain RPC nodes via API
 - [Chainstack](https://chainstack.com/) - Shared and dedicated Ethereum nodes as a service (Mainnet, Ropsten, Rinkeby)
 - [Alchemy](https://alchemyapi.io/) - Blockchain Developer Platform, Ethereum API, and Node Service (Mainnet, Ropsten, Rinkeby, Goerli, Kovan)
 - [ZMOK](https://zmok.io/) - JSON-RPC Ethereum API (Mainnet, Rinkeby, Front-running Mainnet)


### PR DESCRIPTION
NOWNodes is an ultimate blockchain infra provider that lets users get access to full and archive nodes. 
NOWNodes offers multiple interface options including Tendermint, Blockbook, Index and more; available on both mainnets and testnets, depending on the blockchain.
The service provides a high-quality infrastructure that is quick, cost-effective, and reliable.
Node Access: NOWNodes gives users access to 110+ Networks. Because it is important for us to be mentioned in this list!