### PR TITLE
Add perp.wiki — perpetual futures reference resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@
 - [Composing Networks of Automated Market Makers](https://arxiv.org/pdf/2106.00083.pdf) - This paper proposes a mathematical model for AMM composition.
 - [Blockchain Oracle Design Patterns](https://arxiv.org/abs/2106.09349) - In this paper, authors will study and analyze blockchain oracles with regard to how they provide feedback to the blockchain and smart contracts.
 - [CeFi vs. DeFi - Comparing Centralized to Decentralized Finance](https://arxiv.org/abs/2106.08157) - In this work, authors systematically analyze the differences between CeFi and DeFi, covering legal, economic, security, privacy and market manipulation. Authors also provide a structured methodology to differentiate between a CeFi and a DeFi service.
+- [perp.wiki](https://perp.wiki) - Independent perpetual futures reference wiki covering decentralized perpetual protocols, mechanics, funding rates, liquidations, and ecosystem resources — useful reference for developers building on perp DEXes.
 
 #### Ethereum Name Service
 


### PR DESCRIPTION
## perp.wiki

[perp.wiki](https://perp.wiki) is an independent, third-party perpetual futures reference wiki.

- No affiliation with any listed project
- Covers decentralized perpetual protocols, mechanics, funding rates, liquidations, and ecosystem resources
- Free resource for the community

Fits under the **DeFi Further Readings** section because it serves as a practical reference resource for developers building on or studying perpetual DEX protocols — complementing the existing research papers on DeFi mechanics and decentralized exchanges.