### PR TITLE
Add EthGasStation to Ethereum tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,7 @@
 - [Ethereum Gas Charts](https://ethereumprice.org/gas)
 - [Ethereum TxPool Statistics](https://txpool.zengo.com/)
 - [Gas Prices Dashboard ](https://explore.duneanalytics.com/public/dashboards/qswVMdzbyiiZFdnCDSwx1jfYLOjdaokM4CSGNxsH)
+- [EthGasStation](https://ethgasstation.io) - Live Ethereum gas stats, alerts, and workflow tools to help users and teams make better before-send transaction decisions.
 - [The UI from ABI](https://ethcontract.watch)
 - [Oracles Club](https://oracles.club)
 - [Tx Combo](https://furucombo.app)


### PR DESCRIPTION
## Why this PR
Adding EthGasStation because it provides live Ethereum gas stats, alerts, and workflow tooling for before-send transaction decisions.

## Project link
https://ethgasstation.io

## Notes
This seems like a reasonable fit for the Ethereum tools section alongside other gas and transaction-related resources.