### PR TITLE
Add FlashArb Scanner — free DEX arbitrage tool with flash loan calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,7 @@
 - [ERC20 Meta Token Wrapper](https://github.com/arcadeum/erc20-meta-token)
 - [Cancel Ethereum Transaction](https://github.com/mds1/Cancel-Ethereum-Transactions)
 - [Fees WTF Calculator](https://fees.wtf)
+- [FlashArb Scanner](http://18.118.43.47/flasharb/) ([source](https://github.com/JacobMazelin/flasharb-scanner)) - Free real-time DEX arbitrage scanner with flash loan calculations (Uniswap V3 vs SushiSwap). Zero capital required.
 - [Spend Gas Stats](https://txn.finance)
 - [Pools Stats](https://pools.fyi)
 - [Solhint](https://github.com/protofire/solhint)


### PR DESCRIPTION
## Adding FlashArb Scanner to Tools Collection

**What it does:** Free real-time DEX arbitrage scanner between Uniswap V3 and SushiSwap with flash loan profit calculations.

**Why it belongs here:**
- No other free arbitrage scanner in the Tools Collection
- Flash loan integration (AAVE V3 + Balancer V2) — zero capital required to execute
- WebSocket real-time updates every 30 seconds
- Open source: https://github.com/JacobMazelin/flasharb-scanner
- Live demo: http://18.118.43.47/flasharb/

Fits under Ethereum Tools as a free-to-use DeFi tool for developers and traders.