### PR TITLE
Add Pharos stablecoin analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@
 - [Reducing the Volatility of Cryptocurrencies — A Survey of Stablecoins](https://arxiv.org/pdf/2103.01340.pdf) - Authors discuss how stablecoins help reduce the volatility of cryptocurrencies by surveying different types of stablecoins and their stability mechanisms.
 - [Understand Volatility of Algorithmic Stablecoin: Modeling, Verification and Empirical Analysis](https://arxiv.org/pdf/2101.08423.pdf) - Authors performed a systematic empirical analysis on real transaction activities of the Basis Cash stablecoin to relate theoretical possibilities to market observations.
 - [T-Cash: Transferable Fiat Backed Coins](https://arxiv.org/pdf/2105.04485.pdf) - In this paper authors propose a transferable electronic cash scheme using blockchain technology which allows users to continuously reuse coins within the system.
+- [Pharos](https://pharos.watch/) - Open-source stablecoin analytics dashboard tracking peg stress, DEX liquidity, safety ratings, blacklist and freeze events, mint/burn flows, dependencies, and failed stablecoins across pegs and chains.
 
 #### General information:
 


### PR DESCRIPTION
Adds Pharos to the Stable-Coins section as a public, open-source stablecoin analytics dashboard.\n\nKept this to one README entry in the existing style.