### PR TITLE
Add Azul (free public Base RPC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@
 - [ZMOK](https://zmok.io/) - JSON-RPC Ethereum API (Mainnet, Rinkeby, Front-running Mainnet)
 - [Watchdata](https://watchdata.io) - Provide simple and reliable API access to Ethereum blockchain
 - [GetBlock](https://getblock.io/) - Blockchain RPC access to Ethereum blockchain and 50 + others
+- [Azul](https://baseazul.dev/) - Free, no-signup public RPC for Base mainnet (chainId 8453). No API key required.
 
 #### Test Ether Faucets
 


### PR DESCRIPTION
Adding [Azul](https://baseazul.dev) — a free, no-signup public RPC for Base mainnet (chainId 8453).

Placed at the end of the Test Blockchain Networks / RPC providers list, after GetBlock. Same single-line bullet format as the other entries.

- Endpoint: `https://rpc.baseazul.dev`
- No signup, no API key, no logs
- Privacy: https://baseazul.dev/privacy
- Pending on canonical lists: https://github.com/DefiLlama/chainlist/pull/2800, https://github.com/ethereum-lists/chains/pull/8394