### PR TITLE
Add TWZRD Agent Intel MCP server to developer tools 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@
 - [solc-typed-ast compiler](https://github.com/ConsenSys/solc-typed-ast) - TypeScript package providing a normalized typed Solidity AST along with the utilities necessary to generate the AST (from Solc) and traverse/manipulate it.
 - [Slither Explained - for audit](https://telegra.ph/Slither-Explained-04-19)
 - [explorer.swiss-knife.xyz](https://explorer.swiss-knife.xyz/)
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust-scoring MCP server for x402 agents on Solana. Free preflight checks trust + identity signals; signed trust receipt via USDC micropayment (<$0.01, <1s). MCP URL: `https://intel.twzrd.xyz/mcp`
 
 # dApps
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Try this tools** section.

**What is it**: Trust-scoring MCP server for x402 agents on Solana.
- **Free preflight**: On-chain checks for wallet trust + identity signals
- **Paid receipt**: Signed USDC trust receipt via micropayment (<$0.01, <1s settlement)
- **MCP URL**: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP)

Relevant to DeFi developers building AI agents that need to verify counterparty trust before executing on-chain transactions.