### PR TITLE
Add Deep Blue Alpha to Ethereum Tools — free whale flow API

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@
 - [Pools Stats](https://pools.fyi)
 - [CoinPaprika](https://api.coinpaprika.com) - Free crypto market data API — prices, OHLCV, exchanges, and coin metadata for 7,000+ assets. No API key required.
 - [DexPaprika](https://api.dexpaprika.com) - Free DEX data API — real-time pools, token prices, OHLCV, and trades across all chains and DEXes. No API key, no limits.
+- [Deep Blue Alpha](https://deepbluealpha.io) - Free real-time API for Ethereum whale wallet flow — `/api/top-tokens` returns net buy/sell flow across 10,000+ tracked wallets per token across 1H/24H/7D windows. No API key required.
 - [Solhint](https://github.com/protofire/solhint)
 - [Solium](https://github.com/duaraghav8/Solium)
 - [Sol-tester](https://github.com/androlo/sol-tester)


### PR DESCRIPTION
**Deep Blue Alpha** is a free real-time Ethereum whale wallet tracking API.

- `/api/top-tokens` — returns net buy/sell flow per token across 10,000+ tracked wallets, with 1H/24H/7D windows
- `/api/stats` — universe-level aggregate stats
- No API key required, no signup

Positioned alongside CoinPaprika and DexPaprika as a free no-key API in the Ethereum Tools section. Useful for developers building dashboards, bots, or DeFi apps that want on-chain smart money signal without running their own wallet indexer.

Website: https://deepbluealpha.io