### PR TITLE
Add Formo analytics platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@
 - [CeFi vs. DeFi - Comparing Centralized to Decentralized Finance](https://arxiv.org/abs/2106.08157) - In this work, authors systematically analyze the differences between CeFi and DeFi, covering legal, economic, security, privacy and market manipulation. Authors also provide a structured methodology to differentiate between a CeFi and a DeFi service.
 - [perp.wiki](https://perp.wiki) - Independent perpetual futures reference wiki covering decentralized perpetual protocols, mechanics, funding rates, liquidations, and ecosystem resources — useful reference for developers building on perp DEXes.
 - [pigi.finance](https://pigi.finance) - On-chain indexer and analytics API for DeFi vaults. Raw vault activity is turned into clean, comparable data — and full history is available through a single, developer-friendly API.
+- [Formo](https://formo.so) - Product and onchain analytics for Web3 applications, with APIs, a CLI, and a read-only MCP server for SQL, funnels, retention, revenue, users, and wallet profiles.
 
 #### Ethereum Name Service
 


### PR DESCRIPTION
Adds [Formo](https://formo.so) to the DeFi resources section.

Formo provides product and onchain analytics for Web3 applications through APIs, a CLI, and a read-only MCP server, including SQL, funnels, retention, revenue, users, and wallet profiles.

Documentation: https://docs.formo.so/mcp/overview

Validation: destination links resolve and the Markdown diff passes `git diff --check`.

Disclosure: I maintain Formo.
