### PR TITLE
Add Wealthville to DeFI resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,7 @@
 - [perp.wiki](https://perp.wiki) - Independent perpetual futures reference wiki covering decentralized perpetual protocols, mechanics, funding rates, liquidations, and ecosystem resources — useful reference for developers building on perp DEXes.
 - [pigi.finance](https://pigi.finance) - On-chain indexer and analytics API for DeFi vaults. Raw vault activity is turned into clean, comparable data — and full history is available through a single, developer-friendly API.
 - [Formo](https://formo.so) - Product and onchain analytics for Web3 applications, with APIs, a CLI, and a read-only MCP server for SQL, funnels, retention, revenue, users, and wallet profiles.
+- [Wealthville](https://wealthville.net/developers) - Liquidity-pool scoring API for LP and yield strategies: a 0-100 score and an Enter/Hold/Exit/Reduce/Avoid verdict per pool, covering Uniswap v2/v3/v4, Aave, Morpho, Pendle, Curve and Compound across six EVM chains plus Meteora, Orca and Raydium on Solana. Outcomes are graded after impermanent loss and published as a miss-inclusive track record, so the scores can be evaluated before they are relied on. Free keyless REST API, OpenAPI spec, and a read-only MCP server.
 
 #### Ethereum Name Service
 


### PR DESCRIPTION
Adds one entry to the **DeFI** section, alongside the recent analytics/API additions (`pigi.finance`, `Formo`).

**Wealthville** is a scoring layer for liquidity pools, aimed at developers building LP or yield strategies who need a judgement rather than raw TVL and volume to interpret themselves.

- **Coverage** — Uniswap v2/v3/v4, Aave, Morpho, Pendle, Curve and Compound across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC, plus Meteora, Orca and Raydium on Solana.
- **Output** — a 0-100 score and an Enter/Hold/Exit/Reduce/Avoid verdict, with confidence calibrated per protocol rather than pooled across all of them.
- **Graded after impermanent loss**, not on headline APR — which is where most yield numbers mislead.
- **Miss-inclusive track record** at `/api/v1/track-record`: hit rates *and* failures over a rolling 30 days. Currently ENTER 0.63 across 3,043 resolved calls, EXIT 0.69, and REDUCE 0.00 on n=16. The weak class is published on purpose.

Free, keyless REST API with a public OpenAPI spec, plus a read-only MCP server for agent use. No signup.

Disclosure: I maintain this project.